### PR TITLE
Fix duplicate login output and remove footer copyright

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+APP_ENV=local
+APP_DEBUG=true
+APP_URL=http://localhost:8000
+DB_DSN=pgsql:host=127.0.0.1;port=5432;dbname=csr_platform
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+SESSION_NAME=csr_session
+CSRF_SECRET=change-me

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/vendor/
+/.env
+/storage/logs/*.log
+/.phpunit.result.cache
+/.idea/
+.DS_Store
+/node_modules/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,39 @@
+image: php:8.2-cli
+
+stages:
+  - lint
+  - test
+
+variables:
+  COMPOSER_ALLOW_SUPERUSER: "1"
+  APP_ENV: ci
+  APP_DEBUG: "0"
+
+cache:
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+    - vendor/
+    - composer.lock
+
+.install_dependencies: &install_dependencies
+  - apt-get update && apt-get install -y --no-install-recommends git unzip build-essential libpq-dev libsqlite3-dev >/dev/null
+  - docker-php-ext-install pdo_pgsql pdo_sqlite >/dev/null
+  - curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+  - composer install --prefer-dist --no-progress --no-interaction
+
+lint:
+  stage: lint
+  before_script: *install_dependencies
+  script:
+    - find app config database scripts tests -name '*.php' -print0 | xargs -0 -n1 -P4 php -l
+
+phpunit:
+  stage: test
+  before_script: *install_dependencies
+  script:
+    - vendor/bin/phpunit --configuration phpunit.xml --testdox
+  artifacts:
+    when: always
+    paths:
+      - storage/logs/
+    expire_in: 1 week

--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
+# CSR Match Platform (Pure PHP)
 
+This project implements a CSR volunteer matching platform using a custom MVC stack that follows the Boundary–Control–Entity (BCE) methodology. It is written in pure PHP 8.2 with PDO and is designed for coursework that mandates object-oriented middleware, RBAC, and evidence of agile/TDD practices.
+
+## Features
+
+- Custom lightweight framework with Router, Controller, Auth, Session, Validator, and CSRF utilities.
+- Role-based access control using user accounts and profiles (User Admin, CSR Rep, Person In Need, Platform Manager).
+- User Admin console for managing accounts, profiles, suspension, and audit logs.
+- CSR Rep workspace for browsing requests, viewing details, maintaining shortlists, and reviewing service history.
+- PIN portal for creating and managing help requests plus tracking views and shortlist counts.
+- Platform Manager tools for managing service categories and generating daily/weekly/monthly CSV reports.
+- Reporting and seed scripts that populate 100+ records per data type for classroom demos.
+- PHPUnit test suite covering authentication, request workflows, and reporting services.
+
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   composer install
+   ```
+2. **Copy environment file**
+   ```bash
+   cp .env.example .env
+   ```
+3. **Configure database**
+   Update `.env` with your PDO DSN. The default configuration now targets PostgreSQL (`pgsql:host=127.0.0.1;port=5432;dbname=csr_platform`). You can still point the DSN to MySQL or SQLite for local experiments if needed.
+
+4. **Run migrations and seeders**
+   ```bash
+   php scripts/migrate.php
+   php scripts/generate_test_data.php
+   ```
+
+5. **Serve the application**
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+
+6. **Run the automated tests**
+   ```bash
+   composer test
+   ```
+
+## Project Layout
+
+```
+project-root/
+├─ public/                     # Front controller and assets
+├─ app/
+│  ├─ Core/                    # Framework kernel
+│  ├─ Controllers/             # Boundary layer
+│  ├─ Http/Middleware/         # Request guards
+│  ├─ Models/                  # Entity layer
+│  ├─ Repositories/            # Persistence helpers
+│  ├─ Services/                # Control layer
+│  └─ Views/                   # Templates
+├─ config/                     # Routes, database, roles
+├─ database/                   # Migrations, seeders
+├─ scripts/                    # CLI utilities (migrate, seed)
+├─ tests/                      # PHPUnit suite
+└─ storage/logs/               # Application logs
+```
+
+## Demo Credentials
+
+Seed data creates the following sample accounts:
+
+| Role | Username | Password |
+| ---- | -------- | -------- |
+| User Admin | admin@example.com | password123 |
+| CSR Rep | csr.rep@example.com | password123 |
+| Person In Need | pin.user@example.com | password123 |
+| Platform Manager | manager@example.com | password123 |
+
+## License
+
+Educational use only.

--- a/app/Controllers/Admin/CategoryController.php
+++ b/app/Controllers/Admin/CategoryController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Controllers\Admin;
+
+use App\Core\Controller;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Core\Csrf;
+use App\Repositories\CategoryRepository;
+
+class CategoryController extends Controller
+{
+    public function __construct(
+        \App\Core\Request $request,
+        \App\Core\View $view,
+        \App\Core\Response $response,
+        \App\Core\Session $session,
+        \App\Core\Auth $auth,
+        private CategoryRepository $categories,
+        private Validator $validator,
+        protected Csrf $csrf
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+    }
+
+    public function index(): Response
+    {
+        $page = (int) ($this->request->query()['page'] ?? 1);
+        [$categories, $total] = $this->categories->paginate($page, 20, [
+            'status' => $this->request->query()['status'] ?? null,
+            'q' => $this->request->query()['q'] ?? null,
+        ]);
+        return $this->render('admin/categories/index.php', [
+            'title' => 'Service Categories',
+            'categories' => $categories,
+            'total' => $total,
+            'page' => $page,
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return $this->render('admin/categories/form.php', [
+            'title' => 'Create Category',
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function store(): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect('/admin/categories');
+        }
+
+        if (!$this->validator->validate($data, [
+            'name' => 'required|min:3',
+        ])) {
+            $this->session->flash('error', 'Please provide a category name.');
+            return $this->redirect('/admin/categories/create');
+        }
+
+        $this->categories->create($data);
+        $this->session->flash('success', 'Category created.');
+        return $this->redirect('/admin/categories');
+    }
+
+    public function show(int $id): Response
+    {
+        $category = $this->categories->find($id);
+        return $this->render('admin/categories/show.php', [
+            'title' => 'Category Detail',
+            'category' => $category,
+        ]);
+    }
+
+    public function edit(int $id): Response
+    {
+        $category = $this->categories->find($id);
+        return $this->render('admin/categories/form.php', [
+            'title' => 'Edit Category',
+            'category' => $category,
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function update(int $id): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect("/admin/categories/{$id}/edit");
+        }
+
+        $this->categories->update($id, $data);
+        $this->session->flash('success', 'Category updated.');
+        return $this->redirect('/admin/categories');
+    }
+
+    public function destroy(int $id): Response
+    {
+        $this->categories->update($id, ['status' => 'suspended']);
+        $this->session->flash('success', 'Category suspended.');
+        return $this->redirect('/admin/categories');
+    }
+}

--- a/app/Controllers/Admin/ProfileController.php
+++ b/app/Controllers/Admin/ProfileController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Controllers\Admin;
+
+use App\Core\Controller;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Core\Csrf;
+use App\Repositories\ProfileRepository;
+
+class ProfileController extends Controller
+{
+    public function __construct(
+        \App\Core\Request $request,
+        \App\Core\View $view,
+        \App\Core\Response $response,
+        \App\Core\Session $session,
+        \App\Core\Auth $auth,
+        private ProfileRepository $profiles,
+        private Validator $validator,
+        protected Csrf $csrf
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+    }
+
+    public function index(): Response
+    {
+        $page = (int) ($this->request->query()['page'] ?? 1);
+        [$profiles, $total] = $this->profiles->paginate($page, 20, [
+            'role' => $this->request->query()['role'] ?? null,
+            'status' => $this->request->query()['status'] ?? null,
+        ]);
+        return $this->render('admin/profiles/index.php', [
+            'title' => 'User Profiles',
+            'profiles' => $profiles,
+            'total' => $total,
+            'page' => $page,
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return $this->render('admin/profiles/form.php', [
+            'title' => 'Create Profile',
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function store(): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect('/admin/profiles');
+        }
+
+        if (!$this->validator->validate($data, [
+            'role' => 'required',
+            'description' => 'required|min:3',
+        ])) {
+            $this->session->flash('error', 'Please fill in all required fields before submitting.');
+            return $this->redirect('/admin/profiles/create');
+        }
+
+        $data['role'] = trim((string) $data['role']);
+        if ($this->profiles->findByRole($data['role']) !== null) {
+            $this->session->flash('warning', 'A profile for this role already exists.');
+            return $this->redirect('/admin/profiles/create');
+        }
+
+        $this->profiles->create($data);
+        $this->session->flash('success', 'Profile created.');
+        return $this->redirect('/admin/profiles');
+    }
+
+    public function show(int $id): Response
+    {
+        $profile = $this->profiles->find($id);
+        return $this->render('admin/profiles/show.php', [
+            'title' => 'Profile Detail',
+            'profile' => $profile,
+        ]);
+    }
+
+    public function edit(int $id): Response
+    {
+        $profile = $this->profiles->find($id);
+        return $this->render('admin/profiles/form.php', [
+            'title' => 'Edit Profile',
+            'profile' => $profile,
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function update(int $id): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect("/admin/profiles/{$id}/edit");
+        }
+
+        $this->profiles->update($id, $data);
+        $this->session->flash('success', 'Profile updated.');
+        return $this->redirect('/admin/profiles');
+    }
+
+    public function suspend(int $id): Response
+    {
+        $this->profiles->update($id, ['status' => 'suspended']);
+        $this->session->flash('success', 'Profile suspended.');
+        return $this->redirect('/admin/profiles');
+    }
+}

--- a/app/Controllers/Admin/UserController.php
+++ b/app/Controllers/Admin/UserController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Controllers\Admin;
+
+use App\Core\Controller;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Core\Csrf;
+use App\Services\AccountService;
+use App\Repositories\ProfileRepository;
+use DomainException;
+
+class UserController extends Controller
+{
+    public function __construct(
+        \App\Core\Request $request,
+        \App\Core\View $view,
+        \App\Core\Response $response,
+        \App\Core\Session $session,
+        \App\Core\Auth $auth,
+        private AccountService $accounts,
+        private ProfileRepository $profiles,
+        private Validator $validator,
+        protected Csrf $csrf
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+    }
+
+    public function index(): Response
+    {
+        $page = (int) ($this->request->query()['page'] ?? 1);
+        [$users, $total] = $this->accounts->listUsers($page, 20, ['q' => $this->request->query()['q'] ?? null]);
+        return $this->render('admin/users/index.php', [
+            'title' => 'User Accounts',
+            'users' => $users,
+            'total' => $total,
+            'page' => $page,
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return $this->render('admin/users/form.php', [
+            'title' => 'Create User',
+            'profiles' => $this->profiles->paginate(1, 100)[0],
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function store(): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect('/admin/users');
+        }
+
+        if (!$this->validator->validate($data, [
+            'name' => 'required|min:3',
+            'email' => 'required|email',
+            'password' => 'required|min:6',
+            'profile_id' => 'required',
+        ])) {
+            $this->session->flash('error', 'Please fill in all required fields before submitting.');
+            return $this->redirect('/admin/users/create');
+        }
+
+        try {
+            $this->accounts->createUser($data);
+        } catch (DomainException $exception) {
+            $this->session->flash('warning', $exception->getMessage());
+            return $this->redirect('/admin/users/create');
+        }
+
+        $this->session->flash('success', 'User created successfully.');
+        return $this->redirect('/admin/users');
+    }
+
+    public function show(int $id): Response
+    {
+        $user = $this->accounts->findUser($id);
+        return $this->render('admin/users/show.php', [
+            'title' => 'User Detail',
+            'user' => $user,
+        ]);
+    }
+
+    public function edit(int $id): Response
+    {
+        $user = $this->accounts->findUser($id);
+        return $this->render('admin/users/form.php', [
+            'title' => 'Edit User',
+            'user' => $user,
+            'profiles' => $this->profiles->paginate(1, 100)[0],
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function update(int $id): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect("/admin/users/{$id}/edit");
+        }
+
+        $this->accounts->updateUser($id, $data);
+        $this->session->flash('success', 'User updated.');
+        return $this->redirect('/admin/users');
+    }
+
+    public function suspend(int $id): Response
+    {
+        $this->accounts->updateUser($id, ['status' => 'suspended']);
+        $this->session->flash('success', 'User suspended.');
+        return $this->redirect('/admin/users');
+    }
+}

--- a/app/Controllers/CSR/HistoryController.php
+++ b/app/Controllers/CSR/HistoryController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Controllers\CSR;
+
+use App\Core\Controller;
+use App\Core\Response;
+use App\Services\AccountService;
+
+class HistoryController extends Controller
+{
+    public function __construct(
+        \App\Core\Request $request,
+        \App\Core\View $view,
+        \App\Core\Response $response,
+        \App\Core\Session $session,
+        \App\Core\Auth $auth,
+        private AccountService $accounts
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+    }
+
+    public function index(): Response
+    {
+        $filters = [
+            'status' => $this->request->query()['status'] ?? null,
+            'from' => $this->request->query()['from'] ?? null,
+            'to' => $this->request->query()['to'] ?? null,
+        ];
+        $csr = $this->auth->user();
+        $history = $this->accounts->listMatchesForCsr($csr->id, $filters);
+        return $this->render('csr/history/index.php', [
+            'title' => 'Service History',
+            'history' => $history,
+            'filters' => $filters,
+        ]);
+    }
+}

--- a/app/Controllers/CSR/OpportunityController.php
+++ b/app/Controllers/CSR/OpportunityController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Controllers\CSR;
+
+use App\Core\Controller;
+use App\Core\Response;
+use App\Core\Csrf;
+use App\Repositories\RequestRepository;
+use App\Repositories\CategoryRepository;
+use App\Services\AccountService;
+
+class OpportunityController extends Controller
+{
+    public function __construct(
+        \App\Core\Request $request,
+        \App\Core\View $view,
+        \App\Core\Response $response,
+        \App\Core\Session $session,
+        \App\Core\Auth $auth,
+        private RequestRepository $requests,
+        private CategoryRepository $categories,
+        private AccountService $accounts,
+        protected Csrf $csrf
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+    }
+
+    public function index(): Response
+    {
+        $filters = [
+            'category_id' => $this->request->query()['category_id'] ?? null,
+            'q' => $this->request->query()['q'] ?? null,
+            'from' => $this->request->query()['from'] ?? null,
+            'to' => $this->request->query()['to'] ?? null,
+        ];
+        $page = (int) ($this->request->query()['page'] ?? 1);
+        [$items, $total] = $this->requests->searchForCsr($filters, $page, 20);
+        return $this->render('csr/requests/index.php', [
+            'title' => 'Volunteer Opportunities',
+            'requests' => $items,
+            'total' => $total,
+            'page' => $page,
+            'filters' => $filters,
+            'categories' => $this->categories->allActive(),
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function show(int $id): Response
+    {
+        $request = $this->requests->find($id);
+        $this->requests->incrementViews($id);
+        return $this->render('csr/requests/show.php', [
+            'title' => 'Request Detail',
+            'requestItem' => $request,
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function shortlist(int $id): Response
+    {
+        if (!$this->csrf->validate($this->request->post()['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect("/csr/requests/{$id}");
+        }
+
+        $csr = $this->auth->user();
+        $this->accounts->addShortlist($csr->id, $id);
+        $this->session->flash('success', 'Request saved to shortlist.');
+        return $this->redirect('/csr/shortlist');
+    }
+
+    public function shortlistIndex(): Response
+    {
+        $csr = $this->auth->user();
+        $shortlist = $this->accounts->listShortlist($csr->id);
+        return $this->render('csr/shortlist/index.php', [
+            'title' => 'My Shortlist',
+            'shortlist' => $shortlist,
+        ]);
+    }
+}

--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Core\Controller;
+use App\Core\Response;
+
+class DashboardController extends Controller
+{
+    public function index(): Response
+    {
+        $user = $this->auth->user();
+        $csrf = $this->session->get('_csrf_token') ?? '';
+        return $this->render('layouts/dashboard.php', [
+            'title' => 'Dashboard',
+            'user' => $user,
+            'csrfToken' => $csrf,
+        ]);
+    }
+}

--- a/app/Controllers/LoginController.php
+++ b/app/Controllers/LoginController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Core\Auth;
+use App\Core\Controller;
+use App\Core\Csrf;
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Session;
+use App\Core\Validator;
+use App\Core\View;
+use App\Entities\UserAccount;
+
+class LoginController extends Controller
+{
+    private array $roleOptions = [];
+    private Validator $validator;
+    protected Csrf $csrf;
+    private UserAccount $userAccount;
+
+    public function __construct(
+        Request $request,
+        View $view,
+        Response $response,
+        Session $session,
+        Auth $auth,
+        Validator $validator,
+        Csrf $csrf,
+        UserAccount $userAccount
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+        $this->validator = $validator;
+        $this->csrf = $csrf;
+        $this->userAccount = $userAccount;
+    }
+
+    public function show(): Response
+    {
+        return $this->render('auth/login.php', [
+            'title' => 'Sign in',
+            'csrfToken' => $this->csrf->token(),
+            'roleOptions' => $this->getRoleOptions(),
+            'selectedRole' => $this->session->getFlash('login_role', ''),
+            'emailValue' => $this->session->getFlash('login_email', ''),
+        ]);
+    }
+
+    public function submit(): Response
+    {
+        $data = $this->request->post();
+        $role = $data['role'] ?? '';
+        $email = strtolower(trim((string) ($data['email'] ?? '')));
+        $password = $data['password'] ?? '';
+
+        $rememberState = function () use ($role, $email): void {
+            $this->session->flash('login_role', $role);
+            $this->session->flash('login_email', $email);
+        };
+
+        $data['email'] = $email;
+
+        if (!$this->validator->validate($data, [
+            'email' => 'required|email',
+            'password' => 'required|min:6',
+        ])) {
+            $rememberState();
+            $this->session->flash('error', 'Please provide a valid email and password.');
+            return $this->redirect('/');
+        }
+
+        if ($role === '' || !array_key_exists($role, $this->getRoleOptions())) {
+            $rememberState();
+            $this->session->flash('error', 'Please choose a valid account type.');
+            return $this->redirect('/');
+        }
+
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $rememberState();
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect('/');
+        }
+
+        if ($this->validateLogin($email, $password, $role)) {
+            $user = $this->userAccount->authenticatedUser();
+            if ($user !== null) {
+                $this->auth->loginUser($user);
+            }
+            $this->session->flash('success', 'Welcome back!');
+            return $this->redirect('/dashboard');
+        }
+
+        $rememberState();
+        $this->session->flash('error', 'Invalid credentials or suspended account.');
+        return $this->redirect('/');
+    }
+
+    protected function validateLogin(string $email, string $password, string $role): bool
+    {
+        return $this->userAccount->validateUser($email, $password, $role);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getRoleOptions(): array
+    {
+        if ($this->roleOptions === []) {
+            $configPath = dirname(__DIR__, 2) . '/config/roles.php';
+            $roles = require $configPath;
+            foreach ($roles as $key => $meta) {
+                $this->roleOptions[$key] = $meta['name'] ?? ucfirst(str_replace('_', ' ', (string) $key));
+            }
+        }
+
+        return $this->roleOptions;
+    }
+}

--- a/app/Controllers/LogoutController.php
+++ b/app/Controllers/LogoutController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Core\Auth;
+use App\Core\Controller;
+use App\Core\Csrf;
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Session;
+use App\Core\View;
+
+class LogoutController extends Controller
+{
+    protected Csrf $csrf;
+
+    public function __construct(
+        Request $request,
+        View $view,
+        Response $response,
+        Session $session,
+        Auth $auth,
+        Csrf $csrf
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+        $this->csrf = $csrf;
+    }
+
+    public function handle(): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Security token mismatch. Please try again.');
+            return $this->redirect('/dashboard');
+        }
+
+        $this->auth->logout();
+        $this->session->flash('success', 'You have been signed out.');
+        return $this->redirect('/');
+    }
+}

--- a/app/Controllers/PIN/HistoryController.php
+++ b/app/Controllers/PIN/HistoryController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Controllers\PIN;
+
+use App\Core\Controller;
+use App\Core\Response;
+use App\Services\AccountService;
+
+class HistoryController extends Controller
+{
+    public function __construct(
+        \App\Core\Request $request,
+        \App\Core\View $view,
+        \App\Core\Response $response,
+        \App\Core\Session $session,
+        \App\Core\Auth $auth,
+        private AccountService $accounts
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+    }
+
+    public function index(): Response
+    {
+        $filters = [
+            'status' => $this->request->query()['status'] ?? null,
+            'from' => $this->request->query()['from'] ?? null,
+            'to' => $this->request->query()['to'] ?? null,
+        ];
+        $pin = $this->auth->user();
+        $history = $this->accounts->listMatchesForPin($pin->id, $filters);
+        return $this->render('pin/history/index.php', [
+            'title' => 'Completed Matches',
+            'history' => $history,
+            'filters' => $filters,
+        ]);
+    }
+}

--- a/app/Controllers/PIN/RequestController.php
+++ b/app/Controllers/PIN/RequestController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Controllers\PIN;
+
+use App\Core\Controller;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Core\Csrf;
+use App\Repositories\RequestRepository;
+use App\Repositories\CategoryRepository;
+
+class RequestController extends Controller
+{
+    public function __construct(
+        \App\Core\Request $request,
+        \App\Core\View $view,
+        \App\Core\Response $response,
+        \App\Core\Session $session,
+        \App\Core\Auth $auth,
+        private RequestRepository $requests,
+        private CategoryRepository $categories,
+        private Validator $validator,
+        protected Csrf $csrf
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+    }
+
+    public function index(): Response
+    {
+        $pin = $this->auth->user();
+        $filters = [
+            'status' => $this->request->query()['status'] ?? null,
+            'q' => $this->request->query()['q'] ?? null,
+        ];
+        $page = (int) ($this->request->query()['page'] ?? 1);
+        [$requests, $total] = $this->requests->paginateForPin($pin->id, $page, 20, $filters);
+        return $this->render('pin/requests/index.php', [
+            'title' => 'My Requests',
+            'requests' => $requests,
+            'total' => $total,
+            'page' => $page,
+            'categories' => $this->categories->allActive(),
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return $this->render('pin/requests/form.php', [
+            'title' => 'Create Request',
+            'categories' => $this->categories->allActive(),
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function store(): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect('/pin/requests');
+        }
+
+        if (!$this->validator->validate($data, [
+            'title' => 'required|min:3',
+            'description' => 'required|min:10',
+            'location' => 'required',
+            'requested_date' => 'required',
+            'category_id' => 'required',
+        ])) {
+            $this->session->flash('error', 'Please correct the highlighted fields.');
+            return $this->redirect('/pin/requests/create');
+        }
+
+        $data['pin_id'] = $this->auth->user()->id;
+        $this->requests->create($data);
+        $this->session->flash('success', 'Request submitted.');
+        return $this->redirect('/pin/requests');
+    }
+
+    public function show(int $id): Response
+    {
+        $request = $this->requests->find($id);
+        return $this->render('pin/requests/show.php', [
+            'title' => 'Request Detail',
+            'requestItem' => $request,
+        ]);
+    }
+
+    public function edit(int $id): Response
+    {
+        $requestItem = $this->requests->find($id);
+        return $this->render('pin/requests/form.php', [
+            'title' => 'Edit Request',
+            'requestItem' => $requestItem,
+            'categories' => $this->categories->allActive(),
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function update(int $id): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect("/pin/requests/{$id}/edit");
+        }
+
+        $this->requests->update($id, $data);
+        $this->session->flash('success', 'Request updated.');
+        return $this->redirect('/pin/requests');
+    }
+
+    public function destroy(int $id): Response
+    {
+        if (!$this->csrf->validate($this->request->post()['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect('/pin/requests');
+        }
+
+        $this->requests->update($id, ['status' => 'cancelled']);
+        $this->session->flash('success', 'Request cancelled.');
+        return $this->redirect('/pin/requests');
+    }
+}

--- a/app/Controllers/Reports/ReportController.php
+++ b/app/Controllers/Reports/ReportController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Controllers\Reports;
+
+use App\Core\Controller;
+use App\Core\Response;
+use App\Core\Csrf;
+use App\Services\ReportingService;
+
+class ReportController extends Controller
+{
+    public function __construct(
+        \App\Core\Request $request,
+        \App\Core\View $view,
+        \App\Core\Response $response,
+        \App\Core\Session $session,
+        \App\Core\Auth $auth,
+        private ReportingService $reports,
+        protected Csrf $csrf
+    ) {
+        parent::__construct($request, $view, $response, $session, $auth);
+    }
+
+    public function index(): Response
+    {
+        $period = $this->request->query()['period'] ?? 'daily';
+        $data = $this->reports->aggregate($period);
+        return $this->render('reports/index.php', [
+            'title' => 'Platform Reports',
+            'period' => $period,
+            'rows' => $data,
+            'csrfToken' => $this->csrf->token(),
+        ]);
+    }
+
+    public function export(): Response
+    {
+        $data = $this->request->post();
+        if (!$this->csrf->validate($data['_token'] ?? null)) {
+            $this->session->flash('error', 'Invalid security token.');
+            return $this->redirect('/reports');
+        }
+
+        $period = $data['period'] ?? 'daily';
+        $rows = $this->reports->aggregate($period);
+        $csv = $this->toCsv($rows);
+        return (new Response())
+            ->setStatus(200)
+            ->header('Content-Type', 'text/csv')
+            ->header('Content-Disposition', 'attachment; filename="report.csv"')
+            ->setContent($csv);
+    }
+
+    private function toCsv(array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+        fputcsv($handle, ['Period', 'Matches Created', 'Matches Completed']);
+        foreach ($rows as $row) {
+            fputcsv($handle, [$row['period'], $row['matches_created'], $row['matches_completed']]);
+        }
+        rewind($handle);
+        $csv = stream_get_contents($handle) ?: '';
+        fclose($handle);
+        return $csv;
+    }
+}

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Core;
+
+use PDO;
+
+class Application
+{
+    public function __construct(private Container $container)
+    {
+    }
+
+    public function bootstrap(): void
+    {
+        $appConfig = require __DIR__ . '/../../config/app.php';
+        $dbConfig = require __DIR__ . '/../../config/database.php';
+
+        $this->container->set(Container::class, $this->container);
+        $this->container->set(Request::class, fn() => Request::capture());
+        $this->container->set(Response::class, fn() => new Response());
+        $this->container->set(Session::class, fn() => new Session($appConfig['session_name']));
+        $this->container->set(View::class, fn() => new View(__DIR__ . '/../Views'));
+        $this->container->set(PDO::class, function () use ($dbConfig) {
+            return new PDO($dbConfig['dsn'], $dbConfig['username'], $dbConfig['password'], $dbConfig['options']);
+        });
+        $this->container->set(Auth::class, fn(Container $c) => new Auth($c->get(Session::class), $c->get(\App\Repositories\UserRepository::class)));
+        $this->container->set(Csrf::class, fn(Container $c) => new Csrf($c->get(Session::class), $appConfig['csrf_secret']));
+        $this->container->set(\App\Core\Validator::class, fn() => new \App\Core\Validator());
+        $this->container->set(Router::class, fn(Container $c) => new Router($c));
+
+        $this->container->set(\App\Repositories\UserRepository::class, fn(Container $c) => new \App\Repositories\UserRepository($c->get(PDO::class)));
+        $this->container->set(\App\Repositories\ProfileRepository::class, fn(Container $c) => new \App\Repositories\ProfileRepository($c->get(PDO::class)));
+        $this->container->set(\App\Repositories\CategoryRepository::class, fn(Container $c) => new \App\Repositories\CategoryRepository($c->get(PDO::class)));
+        $this->container->set(\App\Repositories\RequestRepository::class, fn(Container $c) => new \App\Repositories\RequestRepository($c->get(PDO::class)));
+        $this->container->set(\App\Repositories\ShortlistRepository::class, fn(Container $c) => new \App\Repositories\ShortlistRepository($c->get(PDO::class)));
+        $this->container->set(\App\Repositories\MatchRepository::class, fn(Container $c) => new \App\Repositories\MatchRepository($c->get(PDO::class)));
+
+        $this->container->set(\App\Entities\UserAccount::class, fn(Container $c) => new \App\Entities\UserAccount(
+            $c->get(\App\Repositories\UserRepository::class)
+        ));
+
+        $this->container->set(\App\Services\AccountService::class, fn(Container $c) => new \App\Services\AccountService(
+            $c->get(\App\Repositories\UserRepository::class),
+            $c->get(\App\Repositories\CategoryRepository::class),
+            $c->get(\App\Repositories\RequestRepository::class),
+            $c->get(\App\Repositories\ShortlistRepository::class),
+            $c->get(\App\Repositories\MatchRepository::class)
+        ));
+        $this->container->set(\App\Services\ReportingService::class, fn(Container $c) => new \App\Services\ReportingService(
+            $c->get(\App\Repositories\MatchRepository::class)
+        ));
+    }
+
+    public function handle(): void
+    {
+        $router = $this->container->get(Router::class);
+        $routes = require __DIR__ . '/../../config/routes.php';
+        $routes($router);
+
+        $request = $this->container->get(Request::class);
+        $response = $router->dispatch($request);
+        $response->send();
+    }
+}

--- a/app/Core/Auth.php
+++ b/app/Core/Auth.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Core;
+
+use App\Models\User;
+use App\Repositories\UserRepository;
+
+class Auth
+{
+    private const SESSION_KEY = 'user_id';
+
+    public function __construct(private Session $session, private UserRepository $users)
+    {
+    }
+
+    public function user(): ?User
+    {
+        $id = $this->session->get(self::SESSION_KEY);
+        return $id ? $this->users->find((int) $id) : null;
+    }
+
+    public function attempt(string $email, string $password, ?string $expectedRole = null): bool
+    {
+        $user = $this->users->findByEmail($email);
+        if (!$user || !$user->isActive()) {
+            return false;
+        }
+
+        $profile = $user->profile;
+        if ($profile && !$profile->isActive()) {
+            return false;
+        }
+
+        if ($expectedRole !== null) {
+            if ($profile === null || $profile->role !== $expectedRole) {
+                return false;
+            }
+        }
+
+        if (!password_verify($password, $user->password_hash)) {
+            return false;
+        }
+
+        $this->loginUser($user);
+        return true;
+    }
+
+    public function logout(): void
+    {
+        $this->session->forget(self::SESSION_KEY);
+        $this->session->regenerate();
+    }
+
+    public function loginUser(User $user): void
+    {
+        $this->session->put(self::SESSION_KEY, $user->id);
+        $this->session->regenerate();
+    }
+
+    public function check(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function hasRole(string $role): bool
+    {
+        $user = $this->user();
+        return $user ? $user->profile?->role === $role : false;
+    }
+}

--- a/app/Core/Container.php
+++ b/app/Core/Container.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Core;
+
+use Closure;
+use InvalidArgumentException;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionUnionType;
+
+class Container
+{
+    /**
+     * @var array<string, Closure|object|string>
+     */
+    private array $bindings = [];
+
+    /**
+     * @param Closure|object|string $concrete
+     */
+    public function set(string $id, mixed $concrete): void
+    {
+        $this->bindings[$id] = $concrete;
+    }
+
+    public function has(string $id): bool
+    {
+        return array_key_exists($id, $this->bindings);
+    }
+
+    public function get(string $id): mixed
+    {
+        if (!$this->has($id)) {
+            if (class_exists($id)) {
+                return $this->build($id);
+            }
+
+            throw new InvalidArgumentException("Service '{$id}' is not bound in the container.");
+        }
+
+        $concrete = $this->bindings[$id];
+
+        if ($concrete instanceof Closure) {
+            return $concrete($this);
+        }
+
+        if (is_string($concrete) && class_exists($concrete)) {
+            return $this->build($concrete);
+        }
+
+        return $concrete;
+    }
+
+    private function build(string $class): object
+    {
+        $reflection = new \ReflectionClass($class);
+        $constructor = $reflection->getConstructor();
+
+        if ($constructor === null || $constructor->getNumberOfParameters() === 0) {
+            return new $class();
+        }
+
+        $dependencies = [];
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $type = $parameter->getType();
+
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+                $dependencies[] = $this->get($type->getName());
+                continue;
+            }
+
+            if ($type instanceof ReflectionUnionType || $type instanceof ReflectionIntersectionType) {
+                $message = sprintf(
+                    "Union or intersection types are not supported when resolving '%s' on '%s'.",
+                    $parameter->getName(),
+                    $class
+                );
+
+                throw new InvalidArgumentException($message);
+            }
+
+            if ($parameter->isDefaultValueAvailable()) {
+                $dependencies[] = $parameter->getDefaultValue();
+            } else {
+                throw new InvalidArgumentException("Cannot resolve dependency '{$parameter->getName()}' for class '{$class}'.");
+            }
+        }
+
+        return $reflection->newInstanceArgs($dependencies);
+    }
+}

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -13,7 +13,7 @@ abstract class Controller
     ) {
     }
 
-    protected function render(string $template, array $data = []): Response
+    protected function render(string $template, array $data = [], ?string $layout = 'layouts/app.php'): Response
     {
         $csrfToken = null;
         if (property_exists($this, 'csrf') && $this->csrf instanceof \App\Core\Csrf) {
@@ -22,13 +22,23 @@ abstract class Controller
             $csrfToken = $this->session->get('_csrf_token') ?? null;
         }
 
-        $content = $this->view->render($template, array_merge($data, [
+        $shared = [
             'authUser' => $this->auth->user(),
             'flash_success' => $this->session->getFlash('success'),
             'flash_error' => $this->session->getFlash('error'),
             'flash_warning' => $this->session->getFlash('warning'),
             'csrfToken' => $csrfToken,
-        ]));
+        ];
+
+        $content = $this->view->render($template, array_merge($shared, $data));
+
+        if ($layout !== null) {
+            $content = $this->view->render($layout, array_merge($shared, $data, [
+                'content' => $content,
+                'title' => $data['title'] ?? null,
+            ]));
+        }
+
         return $this->response->setContent($content);
     }
 

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Core;
+
+abstract class Controller
+{
+    public function __construct(
+        protected Request $request,
+        protected View $view,
+        protected Response $response,
+        protected Session $session,
+        protected Auth $auth
+    ) {
+    }
+
+    protected function render(string $template, array $data = []): Response
+    {
+        $csrfToken = null;
+        if (property_exists($this, 'csrf') && $this->csrf instanceof \App\Core\Csrf) {
+            $csrfToken = $this->csrf->token();
+        } else {
+            $csrfToken = $this->session->get('_csrf_token') ?? null;
+        }
+
+        $content = $this->view->render($template, array_merge($data, [
+            'authUser' => $this->auth->user(),
+            'flash_success' => $this->session->getFlash('success'),
+            'flash_error' => $this->session->getFlash('error'),
+            'flash_warning' => $this->session->getFlash('warning'),
+            'csrfToken' => $csrfToken,
+        ]));
+        return $this->response->setContent($content);
+    }
+
+    protected function redirect(string $url): Response
+    {
+        return $this->response->setStatus(302)->header('Location', $url);
+    }
+}

--- a/app/Core/Csrf.php
+++ b/app/Core/Csrf.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Core;
+
+class Csrf
+{
+    private const TOKEN_KEY = '_csrf_token';
+
+    public function __construct(private Session $session, private string $secret)
+    {
+    }
+
+    public function token(): string
+    {
+        $token = $this->session->get(self::TOKEN_KEY);
+        if (!$token) {
+            $token = hash_hmac('sha256', bin2hex(random_bytes(16)), $this->secret);
+            $this->session->put(self::TOKEN_KEY, $token);
+        }
+        return $token;
+    }
+
+    public function validate(?string $token): bool
+    {
+        $sessionToken = $this->session->get(self::TOKEN_KEY);
+        return $sessionToken !== null && hash_equals($sessionToken, (string) $token);
+    }
+}

--- a/app/Core/Middleware.php
+++ b/app/Core/Middleware.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Core;
+
+abstract class Middleware
+{
+    abstract public function handle(Request $request, callable $next): Response;
+}

--- a/app/Core/Model.php
+++ b/app/Core/Model.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Core;
+
+use PDO;
+
+abstract class Model
+{
+    protected static string $table;
+
+    public function __construct(protected PDO $pdo)
+    {
+    }
+
+    public function find(int $id): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM ' . static::$table . ' WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $result = $stmt->fetch();
+        return $result ?: null;
+    }
+
+    public function all(int $limit = 50, int $offset = 0): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM ' . static::$table . ' LIMIT :limit OFFSET :offset');
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll();
+    }
+}

--- a/app/Core/Paginator.php
+++ b/app/Core/Paginator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Core;
+
+class Paginator
+{
+    public function __construct(
+        public readonly array $items,
+        public readonly int $total,
+        public readonly int $perPage,
+        public readonly int $currentPage
+    ) {
+    }
+
+    public function lastPage(): int
+    {
+        return max(1, (int) ceil($this->total / $this->perPage));
+    }
+
+    public function hasMorePages(): bool
+    {
+        return $this->currentPage < $this->lastPage();
+    }
+}

--- a/app/Core/Request.php
+++ b/app/Core/Request.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Core;
+
+class Request
+{
+    public function __construct(
+        private array $get = [],
+        private array $post = [],
+        private array $server = [],
+        private array $files = [],
+        private array $cookies = []
+    ) {
+    }
+
+    public static function capture(): self
+    {
+        return new self($_GET, $_POST, $_SERVER, $_FILES, $_COOKIE);
+    }
+
+    public function method(): string
+    {
+        return strtoupper($this->server['REQUEST_METHOD'] ?? 'GET');
+    }
+
+    public function path(): string
+    {
+        $uri = $this->server['REQUEST_URI'] ?? '/';
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        return rtrim($path, '/') ?: '/';
+    }
+
+    public function input(string $key, mixed $default = null): mixed
+    {
+        return $this->post[$key] ?? $this->get[$key] ?? $default;
+    }
+
+    public function all(): array
+    {
+        return array_merge($this->get, $this->post);
+    }
+
+    public function query(): array
+    {
+        return $this->get;
+    }
+
+    public function post(): array
+    {
+        return $this->post;
+    }
+
+    public function server(string $key, mixed $default = null): mixed
+    {
+        return $this->server[$key] ?? $default;
+    }
+
+    public function isPost(): bool
+    {
+        return $this->method() === 'POST';
+    }
+}

--- a/app/Core/Response.php
+++ b/app/Core/Response.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Core;
+
+class Response
+{
+    public function __construct(private int $status = 200, private array $headers = [], private string $content = '')
+    {
+    }
+
+    public function setStatus(int $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function header(string $key, string $value): self
+    {
+        $this->headers[$key] = $value;
+        return $this;
+    }
+
+    public function setContent(string $content): self
+    {
+        $this->content = $content;
+        return $this;
+    }
+
+    public function send(): void
+    {
+        http_response_code($this->status);
+        foreach ($this->headers as $key => $value) {
+            header($key . ': ' . $value);
+        }
+        echo $this->content;
+    }
+}

--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Core;
+
+use Closure;
+use RuntimeException;
+
+class Router
+{
+    private array $routes = [];
+    private array $groupStack = [];
+    private array $namedRoutes = [];
+    private Container $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function get(string $uri, array $action): Route
+    {
+        return $this->addRoute('GET', $uri, $action);
+    }
+
+    public function post(string $uri, array $action): Route
+    {
+        return $this->addRoute('POST', $uri, $action);
+    }
+
+    public function group(string $prefix, Closure $callback, array $middleware = []): RouteGroup
+    {
+        $group = new RouteGroup($prefix);
+        if ($middleware) {
+            $group->middleware($middleware);
+        }
+        $this->groupStack[] = $group;
+        $callback($this);
+        array_pop($this->groupStack);
+        return $group;
+    }
+
+    public function resource(string $name, string $controller): void
+    {
+        $this->get("/{$name}", [$controller, 'index']);
+        $this->get("/{$name}/create", [$controller, 'create']);
+        $this->post("/{$name}", [$controller, 'store']);
+        $this->get("/{$name}/{id}", [$controller, 'show']);
+        $this->get("/{$name}/{id}/edit", [$controller, 'edit']);
+        $this->post("/{$name}/{id}", [$controller, 'update']);
+        $this->post("/{$name}/{id}/delete", [$controller, 'destroy']);
+    }
+
+    public function dispatch(Request $request): Response
+    {
+        $method = $request->method();
+        $path = $request->path();
+
+        foreach ($this->routes[$method] ?? [] as $route) {
+            if ($route->matches($path, $params)) {
+                return $this->runRoute($route, $request, $params);
+            }
+        }
+
+        $response = new Response();
+        return $response->setStatus(404)->setContent('Not Found');
+    }
+
+    public function nameRoute(string $name, Route $route): void
+    {
+        $this->namedRoutes[$name] = $route;
+    }
+
+    private function addRoute(string $method, string $uri, array $action): Route
+    {
+        $prefix = $this->currentGroupPrefix();
+        $uri = $this->normalizeUri($prefix . $uri);
+        $route = new Route($method, $uri, $action);
+
+        if ($group = $this->currentGroup()) {
+            $route->middleware($group->getMiddleware());
+        }
+
+        $this->routes[$method][] = $route;
+        return $route;
+    }
+
+    private function normalizeUri(string $uri): string
+    {
+        $uri = '/' . trim($uri, '/');
+        return $uri === '/' ? $uri : rtrim($uri, '/');
+    }
+
+    private function currentGroupPrefix(): string
+    {
+        if (!$this->groupStack) {
+            return '';
+        }
+
+        return implode('', array_map(fn(RouteGroup $group) => $group->getPrefix(), $this->groupStack));
+    }
+
+    private function currentGroup(): ?RouteGroup
+    {
+        return $this->groupStack ? end($this->groupStack) : null;
+    }
+
+    private function runRoute(Route $route, Request $request, array $params): Response
+    {
+        $handler = function (Request $request) use ($route, $params) {
+            [$controllerClass, $method] = $route->getAction();
+            $controller = $this->container->get($controllerClass);
+            return $controller->$method(...$params);
+        };
+
+        $middlewareStack = [];
+        foreach ($route->getMiddleware() as $middleware) {
+            $middlewareStack[] = $this->resolveMiddleware($middleware);
+        }
+
+        $pipeline = array_reduce(
+            array_reverse($middlewareStack),
+            fn(callable $next, Middleware $middleware) => fn(Request $req) => $middleware->handle($req, $next),
+            $handler
+        );
+
+        $response = $pipeline($request);
+        if (!$response instanceof Response) {
+            throw new RuntimeException('Route handler must return a Response instance.');
+        }
+
+        return $response;
+    }
+
+    private function resolveMiddleware(string|callable $middleware): Middleware
+    {
+        if (is_string($middleware)) {
+            if (str_contains($middleware, ':')) {
+                [$name, $argument] = explode(':', $middleware, 2);
+                $instance = $this->container->get($this->middlewareAlias($name));
+                if (method_exists($instance, 'withArgument')) {
+                    $instance = $instance->withArgument($argument);
+                } elseif (property_exists($instance, 'argument')) {
+                    $instance->argument = $argument;
+                }
+                return $instance;
+            }
+
+            return $this->container->get($this->middlewareAlias($middleware));
+        }
+
+        if (is_callable($middleware)) {
+            return new class($middleware) extends Middleware {
+                public function __construct(private $callable) {}
+                public function handle(Request $request, callable $next): Response
+                {
+                    return ($this->callable)($request, $next);
+                }
+            };
+        }
+
+        throw new RuntimeException('Invalid middleware.');
+    }
+
+    private function middlewareAlias(string $alias): string
+    {
+        return match ($alias) {
+            'auth' => \App\Http\Middleware\AuthMiddleware::class,
+            'csrf' => \App\Http\Middleware\CsrfMiddleware::class,
+            'role' => \App\Http\Middleware\RoleMiddleware::class,
+            default => $alias,
+        };
+    }
+}
+
+class Route
+{
+    private array $middleware = [];
+
+    public function __construct(private string $method, private string $uri, private array $action)
+    {
+    }
+
+    public function matches(string $path, ?array &$params = []): bool
+    {
+        $pattern = preg_replace('#\{[^/]+\}#', '([^/]+)', $this->uri);
+        $pattern = '#^' . $pattern . '$#';
+        if (preg_match($pattern, $path, $matches)) {
+            array_shift($matches);
+            $params = $matches;
+            return true;
+        }
+        return false;
+    }
+
+    public function getAction(): array
+    {
+        return $this->action;
+    }
+
+    public function middleware(array|string $middleware): self
+    {
+        $middleware = is_array($middleware) ? $middleware : [$middleware];
+        $this->middleware = array_merge($this->middleware, $middleware);
+        return $this;
+    }
+
+    public function getMiddleware(): array
+    {
+        return $this->middleware;
+    }
+
+    public function name(string $name): self
+    {
+        return $this;
+    }
+}
+
+class RouteGroup
+{
+    private array $middleware = [];
+
+    public function __construct(private string $prefix)
+    {
+    }
+
+    public function middleware(array|string $middleware): self
+    {
+        $this->middleware = array_merge(
+            $this->middleware,
+            is_array($middleware) ? $middleware : [$middleware]
+        );
+        return $this;
+    }
+
+    public function getMiddleware(): array
+    {
+        return $this->middleware;
+    }
+
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+}

--- a/app/Core/Session.php
+++ b/app/Core/Session.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Core;
+
+class Session
+{
+    public function __construct(private string $name)
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_name($this->name);
+            session_start();
+        }
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $_SESSION[$key] ?? $default;
+    }
+
+    public function put(string $key, mixed $value): void
+    {
+        $_SESSION[$key] = $value;
+    }
+
+    public function forget(string $key): void
+    {
+        unset($_SESSION[$key]);
+    }
+
+    public function flash(string $key, mixed $value): void
+    {
+        $_SESSION['_flash'][$key] = $value;
+    }
+
+    public function getFlash(string $key, mixed $default = null): mixed
+    {
+        if (!isset($_SESSION['_flash'][$key])) {
+            return $default;
+        }
+        $value = $_SESSION['_flash'][$key];
+        unset($_SESSION['_flash'][$key]);
+        return $value;
+    }
+
+    public function regenerate(): void
+    {
+        session_regenerate_id(true);
+    }
+
+    public function destroy(): void
+    {
+        $_SESSION = [];
+        if (ini_get('session.use_cookies')) {
+            $params = session_get_cookie_params();
+            setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+        }
+        session_destroy();
+    }
+}

--- a/app/Core/Validator.php
+++ b/app/Core/Validator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Core;
+
+class Validator
+{
+    /** @var array<string, string> */
+    private array $errors = [];
+
+    public function validate(array $data, array $rules): bool
+    {
+        $this->errors = [];
+        foreach ($rules as $field => $ruleString) {
+            $rulesList = explode('|', $ruleString);
+            foreach ($rulesList as $rule) {
+                $rule = trim($rule);
+                $value = $data[$field] ?? null;
+
+                if ($rule === 'required' && ($value === null || $value === '')) {
+                    $this->errors[$field] = 'This field is required.';
+                }
+
+                if ($rule === 'email' && $value && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                    $this->errors[$field] = 'Invalid email format.';
+                }
+
+                if (str_starts_with($rule, 'min:')) {
+                    $min = (int) substr($rule, 4);
+                    if (is_string($value) && strlen($value) < $min) {
+                        $this->errors[$field] = "Must be at least {$min} characters.";
+                    }
+                }
+            }
+        }
+
+        return empty($this->errors);
+    }
+
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/app/Core/View.php
+++ b/app/Core/View.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Core;
+
+class View
+{
+    public function __construct(private string $basePath)
+    {
+    }
+
+    public function render(string $template, array $data = []): string
+    {
+        $path = rtrim($this->basePath, '/').'/'.ltrim($template, '/');
+        if (!file_exists($path)) {
+            throw new \RuntimeException("View '{$template}' not found at '{$path}'.");
+        }
+
+        extract($data, EXTR_SKIP);
+        ob_start();
+        include $path;
+        return ob_get_clean() ?: '';
+    }
+}

--- a/app/Entities/UserAccount.php
+++ b/app/Entities/UserAccount.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Entities;
+
+use App\Models\User;
+use App\Repositories\UserRepository;
+
+class UserAccount
+{
+    private ?User $authenticatedUser = null;
+
+    public function __construct(private UserRepository $users)
+    {
+    }
+
+    public function validateUser(string $email, string $password, string $role): bool
+    {
+        $this->authenticatedUser = null;
+        $user = $this->users->findByEmail($email);
+
+        if ($user === null || !$user->isActive()) {
+            return false;
+        }
+
+        $profile = $user->profile;
+        if ($profile === null || !$profile->isActive()) {
+            return false;
+        }
+
+        if ($profile->role !== $role) {
+            return false;
+        }
+
+        if (!password_verify($password, $user->password_hash)) {
+            return false;
+        }
+
+        $this->authenticatedUser = $user;
+        return true;
+    }
+
+    public function authenticatedUser(): ?User
+    {
+        return $this->authenticatedUser;
+    }
+}

--- a/app/Http/Middleware/AuthMiddleware.php
+++ b/app/Http/Middleware/AuthMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Core\Auth;
+use App\Core\Middleware;
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Session;
+
+class AuthMiddleware extends Middleware
+{
+    public function __construct(private Auth $auth, private Session $session)
+    {
+    }
+
+    public function handle(Request $request, callable $next): Response
+    {
+        if (!$this->auth->check()) {
+            $this->session->flash('error', 'Please log in to continue.');
+            return (new Response())->setStatus(302)->header('Location', '/');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/CsrfMiddleware.php
+++ b/app/Http/Middleware/CsrfMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Core\Csrf;
+use App\Core\Middleware;
+use App\Core\Request;
+use App\Core\Response;
+
+class CsrfMiddleware extends Middleware
+{
+    public function __construct(private Csrf $csrf)
+    {
+    }
+
+    public function handle(Request $request, callable $next): Response
+    {
+        if ($request->isPost()) {
+            $token = $request->post()['_token'] ?? null;
+            if (!$this->csrf->validate($token)) {
+                return (new Response())->setStatus(419)->setContent('Invalid CSRF token.');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Core\Auth;
+use App\Core\Middleware;
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Session;
+
+class RoleMiddleware extends Middleware
+{
+    private string $role;
+
+    public function __construct(private Auth $auth, private Session $session)
+    {
+    }
+
+    public function withArgument(string $role): self
+    {
+        $clone = clone $this;
+        $clone->role = $role;
+        return $clone;
+    }
+
+    public function handle(Request $request, callable $next): Response
+    {
+        if (!$this->auth->check() || !$this->auth->hasRole($this->role)) {
+            $this->session->flash('error', 'You do not have permission to access this area.');
+            return (new Response())->setStatus(302)->header('Location', '/dashboard');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/MatchRecord.php
+++ b/app/Models/MatchRecord.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+class MatchRecord
+{
+    public function __construct(
+        public int $id,
+        public int $csr_id,
+        public int $request_id,
+        public string $status,
+        public string $matched_at,
+        public ?string $completed_at
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) $data['id'],
+            (int) $data['csr_id'],
+            (int) $data['request_id'],
+            $data['status'],
+            $data['matched_at'],
+            $data['completed_at'] ?? null
+        );
+    }
+}

--- a/app/Models/PinRequest.php
+++ b/app/Models/PinRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+class PinRequest
+{
+    public function __construct(
+        public int $id,
+        public int $pin_id,
+        public int $category_id,
+        public string $title,
+        public string $description,
+        public string $location,
+        public string $status,
+        public string $requested_date,
+        public int $views_count,
+        public int $shortlist_count,
+        public string $created_at,
+        public string $updated_at
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) $data['id'],
+            (int) $data['pin_id'],
+            (int) $data['category_id'],
+            $data['title'],
+            $data['description'],
+            $data['location'],
+            $data['status'],
+            $data['requested_date'],
+            (int) $data['views_count'],
+            (int) $data['shortlist_count'],
+            $data['created_at'],
+            $data['updated_at']
+        );
+    }
+}

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+class Profile
+{
+    public function __construct(
+        public int $id,
+        public string $role,
+        public string $description,
+        public string $status,
+        public string $created_at,
+        public string $updated_at
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) $data['id'],
+            $data['role'],
+            $data['description'],
+            $data['status'],
+            $data['created_at'],
+            $data['updated_at']
+        );
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === 'active';
+    }
+}

--- a/app/Models/ServiceCategory.php
+++ b/app/Models/ServiceCategory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+class ServiceCategory
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $status,
+        public string $created_at,
+        public string $updated_at
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) $data['id'],
+            $data['name'],
+            $data['status'],
+            $data['created_at'],
+            $data['updated_at']
+        );
+    }
+}

--- a/app/Models/Shortlist.php
+++ b/app/Models/Shortlist.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+class Shortlist
+{
+    public function __construct(
+        public int $id,
+        public int $csr_id,
+        public int $request_id,
+        public string $created_at
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) $data['id'],
+            (int) $data['csr_id'],
+            (int) $data['request_id'],
+            $data['created_at']
+        );
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+class User
+{
+    public function __construct(
+        public int $id,
+        public int $profile_id,
+        public string $name,
+        public string $email,
+        public string $password_hash,
+        public string $status,
+        public string $created_at,
+        public string $updated_at,
+        public ?Profile $profile = null
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) $data['id'],
+            (int) $data['profile_id'],
+            $data['name'],
+            $data['email'],
+            $data['password_hash'],
+            $data['status'],
+            $data['created_at'],
+            $data['updated_at'],
+        );
+    }
+
+    public function withProfile(?Profile $profile): self
+    {
+        $this->profile = $profile;
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === 'active';
+    }
+}

--- a/app/Repositories/CategoryRepository.php
+++ b/app/Repositories/CategoryRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\ServiceCategory;
+use PDO;
+
+class CategoryRepository extends Repository
+{
+    public function allActive(): array
+    {
+        $stmt = $this->pdo->query("SELECT * FROM service_categories WHERE status = 'active' ORDER BY name");
+        return array_map(fn($row) => ServiceCategory::fromArray($row), $stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    public function paginate(int $page = 1, int $perPage = 20, array $filters = []): array
+    {
+        $offset = ($page - 1) * $perPage;
+        $sql = 'SELECT * FROM service_categories WHERE 1=1';
+        if (!empty($filters['status'])) {
+            $sql .= ' AND status = :status';
+        }
+        if (!empty($filters['q'])) {
+            $sql .= ' AND name LIKE :q';
+        }
+        $sql .= ' ORDER BY name LIMIT :limit OFFSET :offset';
+
+        $stmt = $this->pdo->prepare($sql);
+        if (!empty($filters['status'])) {
+            $stmt->bindValue(':status', $filters['status']);
+        }
+        if (!empty($filters['q'])) {
+            $stmt->bindValue(':q', '%' . $filters['q'] . '%');
+        }
+        $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $items = array_map(fn($row) => ServiceCategory::fromArray($row), $stmt->fetchAll(PDO::FETCH_ASSOC));
+
+        $countSql = 'SELECT COUNT(*) FROM service_categories WHERE 1=1';
+        if (!empty($filters['status'])) {
+            $countSql .= ' AND status = :status';
+        }
+        if (!empty($filters['q'])) {
+            $countSql .= ' AND name LIKE :q';
+        }
+        $countStmt = $this->pdo->prepare($countSql);
+        if (!empty($filters['status'])) {
+            $countStmt->bindValue(':status', $filters['status']);
+        }
+        if (!empty($filters['q'])) {
+            $countStmt->bindValue(':q', '%' . $filters['q'] . '%');
+        }
+        $countStmt->execute();
+        $total = (int) $countStmt->fetchColumn();
+
+        return [$items, $total];
+    }
+
+    public function create(array $data): int
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO service_categories (name, status, created_at, updated_at) VALUES (:name, :status, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'status' => $data['status'] ?? 'active',
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    public function find(int $id): ?ServiceCategory
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM service_categories WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? ServiceCategory::fromArray($row) : null;
+    }
+
+    public function update(int $id, array $data): void
+    {
+        $fields = [];
+        $params = ['id' => $id];
+        foreach ($data as $key => $value) {
+            $fields[] = "$key = :$key";
+            $params[$key] = $value;
+        }
+        $params['updated_at'] = date('Y-m-d H:i:s');
+        $fields[] = 'updated_at = :updated_at';
+        $sql = 'UPDATE service_categories SET ' . implode(', ', $fields) . ' WHERE id = :id';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+    }
+}

--- a/app/Repositories/MatchRepository.php
+++ b/app/Repositories/MatchRepository.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\MatchRecord;
+use PDO;
+
+class MatchRepository extends Repository
+{
+    public function listForCsr(int $csrId, array $filters = []): array
+    {
+        $sql = 'SELECT * FROM matches WHERE csr_id = :csr_id';
+        $params = ['csr_id' => $csrId];
+        if (!empty($filters['status'])) {
+            $sql .= ' AND status = :status';
+        }
+        if (!empty($filters['from'])) {
+            $sql .= ' AND matched_at >= :from';
+        }
+        if (!empty($filters['to'])) {
+            $sql .= ' AND matched_at <= :to';
+        }
+        $sql .= ' ORDER BY matched_at DESC';
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue(':'.$key, $value);
+        }
+        if (!empty($filters['status'])) {
+            $stmt->bindValue(':status', $filters['status']);
+        }
+        if (!empty($filters['from'])) {
+            $stmt->bindValue(':from', $filters['from']);
+        }
+        if (!empty($filters['to'])) {
+            $stmt->bindValue(':to', $filters['to']);
+        }
+        $stmt->execute();
+        return array_map(fn($row) => MatchRecord::fromArray($row), $stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    public function listForPin(int $pinId, array $filters = []): array
+    {
+        $sql = 'SELECT m.* FROM matches m JOIN pin_requests r ON r.id = m.request_id WHERE r.pin_id = :pin_id';
+        $params = ['pin_id' => $pinId];
+        if (!empty($filters['status'])) {
+            $sql .= ' AND m.status = :status';
+        }
+        if (!empty($filters['from'])) {
+            $sql .= ' AND m.matched_at >= :from';
+        }
+        if (!empty($filters['to'])) {
+            $sql .= ' AND m.matched_at <= :to';
+        }
+        $sql .= ' ORDER BY m.matched_at DESC';
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue(':'.$key, $value);
+        }
+        if (!empty($filters['status'])) {
+            $stmt->bindValue(':status', $filters['status']);
+        }
+        if (!empty($filters['from'])) {
+            $stmt->bindValue(':from', $filters['from']);
+        }
+        if (!empty($filters['to'])) {
+            $stmt->bindValue(':to', $filters['to']);
+        }
+        $stmt->execute();
+        return array_map(fn($row) => MatchRecord::fromArray($row), $stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    public function aggregateByPeriod(string $period): array
+    {
+        $stmt = $this->pdo->query('SELECT matched_at, completed_at FROM matches');
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $groups = [];
+
+        foreach ($rows as $row) {
+            $matchedAt = new \DateTimeImmutable($row['matched_at']);
+            $completedAt = $row['completed_at'] ? new \DateTimeImmutable($row['completed_at']) : null;
+
+            $key = match ($period) {
+                'weekly' => $matchedAt->format('o-\WW'),
+                'monthly' => $matchedAt->format('Y-m'),
+                default => $matchedAt->format('Y-m-d'),
+            };
+
+            if (!isset($groups[$key])) {
+                $groups[$key] = ['period' => $key, 'matches_created' => 0, 'matches_completed' => 0];
+            }
+
+            $groups[$key]['matches_created']++;
+            if ($completedAt) {
+                $groups[$key]['matches_completed']++;
+            }
+        }
+
+        krsort($groups);
+        return array_values($groups);
+    }
+}

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Profile;
+use PDO;
+
+class ProfileRepository extends Repository
+{
+    public function paginate(int $page = 1, int $perPage = 20, array $filters = []): array
+    {
+        $offset = ($page - 1) * $perPage;
+        $sql = 'SELECT * FROM profiles WHERE 1=1';
+        if (!empty($filters['role'])) {
+            $sql .= ' AND role = :role';
+        }
+        if (!empty($filters['status'])) {
+            $sql .= ' AND status = :status';
+        }
+        $sql .= ' ORDER BY created_at DESC LIMIT :limit OFFSET :offset';
+        $stmt = $this->pdo->prepare($sql);
+        if (!empty($filters['role'])) {
+            $stmt->bindValue(':role', $filters['role']);
+        }
+        if (!empty($filters['status'])) {
+            $stmt->bindValue(':status', $filters['status']);
+        }
+        $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $items = array_map(fn($row) => Profile::fromArray($row), $stmt->fetchAll(PDO::FETCH_ASSOC));
+
+        $countSql = 'SELECT COUNT(*) FROM profiles WHERE 1=1';
+        if (!empty($filters['role'])) {
+            $countSql .= ' AND role = :role';
+        }
+        if (!empty($filters['status'])) {
+            $countSql .= ' AND status = :status';
+        }
+        $countStmt = $this->pdo->prepare($countSql);
+        if (!empty($filters['role'])) {
+            $countStmt->bindValue(':role', $filters['role']);
+        }
+        if (!empty($filters['status'])) {
+            $countStmt->bindValue(':status', $filters['status']);
+        }
+        $countStmt->execute();
+        $total = (int) $countStmt->fetchColumn();
+
+        return [$items, $total];
+    }
+
+    public function create(array $data): int
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO profiles (role, description, status, created_at, updated_at) VALUES (:role, :description, :status, :created_at, :updated_at)');
+        $stmt->execute([
+            'role' => $data['role'],
+            'description' => $data['description'],
+            'status' => $data['status'] ?? 'active',
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    public function find(int $id): ?Profile
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM profiles WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? Profile::fromArray($row) : null;
+    }
+
+    public function update(int $id, array $data): void
+    {
+        $fields = [];
+        $params = ['id' => $id];
+        foreach ($data as $key => $value) {
+            $fields[] = "$key = :$key";
+            $params[$key] = $value;
+        }
+        $params['updated_at'] = date('Y-m-d H:i:s');
+        $fields[] = 'updated_at = :updated_at';
+        $sql = 'UPDATE profiles SET ' . implode(', ', $fields) . ' WHERE id = :id';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+    }
+
+    public function findByRole(string $role): ?Profile
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM profiles WHERE LOWER(role) = LOWER(:role) LIMIT 1');
+        $stmt->execute(['role' => $role]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? Profile::fromArray($row) : null;
+    }
+}

--- a/app/Repositories/Repository.php
+++ b/app/Repositories/Repository.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Repositories;
+
+use PDO;
+
+abstract class Repository
+{
+    public function __construct(protected PDO $pdo)
+    {
+    }
+}

--- a/app/Repositories/RequestRepository.php
+++ b/app/Repositories/RequestRepository.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\PinRequest;
+use PDO;
+
+class RequestRepository extends Repository
+{
+    public function find(int $id): ?PinRequest
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM pin_requests WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? PinRequest::fromArray($row) : null;
+    }
+
+    public function paginateForPin(int $pinId, int $page = 1, int $perPage = 20, array $filters = []): array
+    {
+        $offset = ($page - 1) * $perPage;
+        $sql = 'SELECT * FROM pin_requests WHERE pin_id = :pin_id';
+        $params = ['pin_id' => $pinId];
+        if (!empty($filters['status'])) {
+            $sql .= ' AND status = :status';
+        }
+        if (!empty($filters['q'])) {
+            $sql .= ' AND (title LIKE :q OR location LIKE :q)';
+        }
+        $sql .= ' ORDER BY created_at DESC LIMIT :limit OFFSET :offset';
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue(':'.$key, $value);
+        }
+        if (!empty($filters['status'])) {
+            $stmt->bindValue(':status', $filters['status']);
+        }
+        if (!empty($filters['q'])) {
+            $stmt->bindValue(':q', '%' . $filters['q'] . '%');
+        }
+        $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $items = array_map(fn($row) => PinRequest::fromArray($row), $stmt->fetchAll(PDO::FETCH_ASSOC));
+
+        $countSql = 'SELECT COUNT(*) FROM pin_requests WHERE pin_id = :pin_id';
+        if (!empty($filters['status'])) {
+            $countSql .= ' AND status = :status';
+        }
+        if (!empty($filters['q'])) {
+            $countSql .= ' AND (title LIKE :q OR location LIKE :q)';
+        }
+        $countStmt = $this->pdo->prepare($countSql);
+        $countStmt->bindValue(':pin_id', $pinId, PDO::PARAM_INT);
+        if (!empty($filters['status'])) {
+            $countStmt->bindValue(':status', $filters['status']);
+        }
+        if (!empty($filters['q'])) {
+            $countStmt->bindValue(':q', '%' . $filters['q'] . '%');
+        }
+        $countStmt->execute();
+        $total = (int) $countStmt->fetchColumn();
+
+        return [$items, $total];
+    }
+
+    public function create(array $data): int
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO pin_requests (pin_id, category_id, title, description, location, status, requested_date, views_count, shortlist_count, created_at, updated_at) VALUES (:pin_id, :category_id, :title, :description, :location, :status, :requested_date, :views_count, :shortlist_count, :created_at, :updated_at)');
+        $stmt->execute([
+            'pin_id' => $data['pin_id'],
+            'category_id' => $data['category_id'],
+            'title' => $data['title'],
+            'description' => $data['description'],
+            'location' => $data['location'],
+            'status' => $data['status'] ?? 'open',
+            'requested_date' => $data['requested_date'],
+            'views_count' => $data['views_count'] ?? 0,
+            'shortlist_count' => $data['shortlist_count'] ?? 0,
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    public function update(int $id, array $data): void
+    {
+        $fields = [];
+        $params = ['id' => $id];
+        foreach ($data as $key => $value) {
+            $fields[] = "$key = :$key";
+            $params[$key] = $value;
+        }
+        $params['updated_at'] = date('Y-m-d H:i:s');
+        $fields[] = 'updated_at = :updated_at';
+        $sql = 'UPDATE pin_requests SET ' . implode(', ', $fields) . ' WHERE id = :id';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+    }
+
+    public function incrementViews(int $id): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE pin_requests SET views_count = views_count + 1 WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+    }
+
+    public function incrementShortlist(int $id): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE pin_requests SET shortlist_count = shortlist_count + 1 WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+    }
+
+    public function searchForCsr(array $filters = [], int $page = 1, int $perPage = 20): array
+    {
+        $offset = ($page - 1) * $perPage;
+        $sql = 'SELECT * FROM pin_requests WHERE status IN (\'open\', \'in_progress\')';
+        if (!empty($filters['category_id'])) {
+            $sql .= ' AND category_id = :category_id';
+        }
+        if (!empty($filters['q'])) {
+            $sql .= ' AND (title LIKE :q OR description LIKE :q OR location LIKE :q)';
+        }
+        if (!empty($filters['from'])) {
+            $sql .= ' AND requested_date >= :from';
+        }
+        if (!empty($filters['to'])) {
+            $sql .= ' AND requested_date <= :to';
+        }
+        $sql .= ' ORDER BY requested_date ASC LIMIT :limit OFFSET :offset';
+
+        $stmt = $this->pdo->prepare($sql);
+        if (!empty($filters['category_id'])) {
+            $stmt->bindValue(':category_id', $filters['category_id']);
+        }
+        if (!empty($filters['q'])) {
+            $stmt->bindValue(':q', '%' . $filters['q'] . '%');
+        }
+        if (!empty($filters['from'])) {
+            $stmt->bindValue(':from', $filters['from']);
+        }
+        if (!empty($filters['to'])) {
+            $stmt->bindValue(':to', $filters['to']);
+        }
+        $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $items = array_map(fn($row) => PinRequest::fromArray($row), $stmt->fetchAll(PDO::FETCH_ASSOC));
+
+        $countSql = 'SELECT COUNT(*) FROM pin_requests WHERE status IN (\'open\', \'in_progress\')';
+        if (!empty($filters['category_id'])) {
+            $countSql .= ' AND category_id = :category_id';
+        }
+        if (!empty($filters['q'])) {
+            $countSql .= ' AND (title LIKE :q OR description LIKE :q OR location LIKE :q)';
+        }
+        if (!empty($filters['from'])) {
+            $countSql .= ' AND requested_date >= :from';
+        }
+        if (!empty($filters['to'])) {
+            $countSql .= ' AND requested_date <= :to';
+        }
+        $countStmt = $this->pdo->prepare($countSql);
+        if (!empty($filters['category_id'])) {
+            $countStmt->bindValue(':category_id', $filters['category_id']);
+        }
+        if (!empty($filters['q'])) {
+            $countStmt->bindValue(':q', '%' . $filters['q'] . '%');
+        }
+        if (!empty($filters['from'])) {
+            $countStmt->bindValue(':from', $filters['from']);
+        }
+        if (!empty($filters['to'])) {
+            $countStmt->bindValue(':to', $filters['to']);
+        }
+        $countStmt->execute();
+        $total = (int) $countStmt->fetchColumn();
+
+        return [$items, $total];
+    }
+}

--- a/app/Repositories/ShortlistRepository.php
+++ b/app/Repositories/ShortlistRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Shortlist;
+use PDO;
+
+class ShortlistRepository extends Repository
+{
+    public function findByCsrAndRequest(int $csrId, int $requestId): ?Shortlist
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM shortlists WHERE csr_id = :csr_id AND request_id = :request_id');
+        $stmt->execute(['csr_id' => $csrId, 'request_id' => $requestId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? Shortlist::fromArray($row) : null;
+    }
+
+    public function add(int $csrId, int $requestId): Shortlist
+    {
+        $existing = $this->findByCsrAndRequest($csrId, $requestId);
+        if ($existing) {
+            return $existing;
+        }
+        $stmt = $this->pdo->prepare('INSERT INTO shortlists (csr_id, request_id, created_at) VALUES (:csr_id, :request_id, :created_at)');
+        $stmt->execute([
+            'csr_id' => $csrId,
+            'request_id' => $requestId,
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+        return new Shortlist((int) $this->pdo->lastInsertId(), $csrId, $requestId, date('Y-m-d H:i:s'));
+    }
+
+    public function listForCsr(int $csrId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM shortlists WHERE csr_id = :csr_id ORDER BY created_at DESC');
+        $stmt->execute(['csr_id' => $csrId]);
+        return array_map(fn($row) => Shortlist::fromArray($row), $stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+}

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Profile;
+use App\Models\User;
+use PDO;
+
+class UserRepository extends Repository
+{
+    public function find(int $id): ?User
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM users WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $data = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $data ? User::fromArray($data)->withProfile($this->loadProfile((int) $data['profile_id'])) : null;
+    }
+
+    public function findByEmail(string $email): ?User
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM users WHERE LOWER(email) = LOWER(:email)');
+        $stmt->execute(['email' => $email]);
+        $data = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $data ? User::fromArray($data)->withProfile($this->loadProfile((int) $data['profile_id'])) : null;
+    }
+
+    public function paginate(int $page = 1, int $perPage = 20, array $filters = []): array
+    {
+        $offset = ($page - 1) * $perPage;
+        $sql = 'SELECT * FROM users WHERE 1=1';
+        $params = [];
+        if (!empty($filters['q'])) {
+            $sql .= ' AND (email LIKE :q OR name LIKE :q)';
+            $params['q'] = '%' . $filters['q'] . '%';
+        }
+        $sql .= ' ORDER BY created_at DESC LIMIT :limit OFFSET :offset';
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value);
+        }
+        $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $items = array_map(fn($row) => User::fromArray($row)->withProfile($this->loadProfile((int) $row['profile_id'])), $stmt->fetchAll(PDO::FETCH_ASSOC));
+
+        $countSql = 'SELECT COUNT(*) FROM users WHERE 1=1';
+        if (!empty($filters['q'])) {
+            $countSql .= ' AND (email LIKE :q OR name LIKE :q)';
+        }
+        $countStmt = $this->pdo->prepare($countSql);
+        if (!empty($filters['q'])) {
+            $countStmt->bindValue(':q', '%' . $filters['q'] . '%');
+        }
+        $countStmt->execute();
+        $total = (int) $countStmt->fetchColumn();
+
+        return [$items, $total];
+    }
+
+    public function create(array $data): int
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO users (profile_id, name, email, password_hash, status, created_at, updated_at) VALUES (:profile_id, :name, :email, :password_hash, :status, :created_at, :updated_at)');
+        $stmt->execute([
+            'profile_id' => $data['profile_id'],
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password_hash' => $data['password_hash'],
+            'status' => $data['status'] ?? 'active',
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    public function update(int $id, array $data): void
+    {
+        $fields = [];
+        $params = ['id' => $id];
+        foreach ($data as $key => $value) {
+            $fields[] = "$key = :$key";
+            $params[$key] = $value;
+        }
+        $params['updated_at'] = date('Y-m-d H:i:s');
+        $fields[] = 'updated_at = :updated_at';
+        $sql = 'UPDATE users SET ' . implode(', ', $fields) . ' WHERE id = :id';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+    }
+
+    private function loadProfile(int $id): ?Profile
+    {
+        if ($id === 0) {
+            return null;
+        }
+        $stmt = $this->pdo->prepare('SELECT * FROM profiles WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $data = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $data ? Profile::fromArray($data) : null;
+    }
+}

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\UserRepository;
+use App\Repositories\CategoryRepository;
+use App\Repositories\RequestRepository;
+use App\Repositories\MatchRepository;
+use App\Repositories\ShortlistRepository;
+use App\Models\User;
+use App\Models\PinRequest;
+use App\Models\Shortlist;
+use DomainException;
+
+class AccountService
+{
+    public function __construct(
+        private UserRepository $users,
+        private CategoryRepository $categories,
+        private RequestRepository $requests,
+        private ShortlistRepository $shortlists,
+        private MatchRepository $matches
+    ) {
+    }
+
+    public function listUsers(int $page, int $perPage, array $filters = []): array
+    {
+        return $this->users->paginate($page, $perPage, $filters);
+    }
+
+    public function createUser(array $data): int
+    {
+        $email = strtolower(trim((string) ($data['email'] ?? '')));
+        if ($email === '') {
+            throw new DomainException('Email is required.');
+        }
+
+        if ($this->users->findByEmail($email) !== null) {
+            throw new DomainException('An account with this email already exists.');
+        }
+
+        $data['email'] = $email;
+        $data['password_hash'] = password_hash($data['password'], PASSWORD_BCRYPT);
+        unset($data['password']);
+        return $this->users->create($data);
+    }
+
+    public function updateUser(int $id, array $data): void
+    {
+        if (!empty($data['password'])) {
+            $data['password_hash'] = password_hash($data['password'], PASSWORD_BCRYPT);
+        }
+        unset($data['password']);
+        $this->users->update($id, $data);
+    }
+
+    public function findUser(int $id): ?User
+    {
+        return $this->users->find($id);
+    }
+
+    public function listCategories(int $page, int $perPage, array $filters = []): array
+    {
+        return $this->categories->paginate($page, $perPage, $filters);
+    }
+
+    public function createRequest(array $data): int
+    {
+        return $this->requests->create($data);
+    }
+
+    public function updateRequest(int $id, array $data): void
+    {
+        $this->requests->update($id, $data);
+    }
+
+    public function findRequest(int $id): ?PinRequest
+    {
+        return $this->requests->find($id);
+    }
+
+    public function addShortlist(int $csrId, int $requestId): Shortlist
+    {
+        $shortlist = $this->shortlists->add($csrId, $requestId);
+        $this->requests->incrementShortlist($requestId);
+        return $shortlist;
+    }
+
+    public function listShortlist(int $csrId): array
+    {
+        return $this->shortlists->listForCsr($csrId);
+    }
+
+    public function listMatchesForCsr(int $csrId, array $filters = []): array
+    {
+        return $this->matches->listForCsr($csrId, $filters);
+    }
+
+    public function listMatchesForPin(int $pinId, array $filters = []): array
+    {
+        return $this->matches->listForPin($pinId, $filters);
+    }
+}

--- a/app/Services/ReportingService.php
+++ b/app/Services/ReportingService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\MatchRepository;
+
+class ReportingService
+{
+    public function __construct(private MatchRepository $matches)
+    {
+    }
+
+    public function aggregate(string $period): array
+    {
+        return $this->matches->aggregateByPeriod($period);
+    }
+}

--- a/app/Views/admin/categories/form.php
+++ b/app/Views/admin/categories/form.php
@@ -1,0 +1,19 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($title, ENT_QUOTES) ?></h1>
+    <form method="POST" action="<?= isset($category) ? '/admin/categories/' . $category->id : '/admin/categories' ?>" class="form">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken ?? '', ENT_QUOTES) ?>">
+        <label>Name
+            <input type="text" name="name" value="<?= htmlspecialchars($category->name ?? '', ENT_QUOTES) ?>" required>
+        </label>
+        <label>Status
+            <select name="status">
+                <option value="active" <?= isset($category) && $category->status === 'active' ? 'selected' : '' ?>>Active</option>
+                <option value="suspended" <?= isset($category) && $category->status === 'suspended' ? 'selected' : '' ?>>Suspended</option>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/admin/categories" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/categories/form.php
+++ b/app/Views/admin/categories/form.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($title, ENT_QUOTES) ?></h1>
     <form method="POST" action="<?= isset($category) ? '/admin/categories/' . $category->id : '/admin/categories' ?>" class="form">
@@ -16,4 +15,3 @@
         <a href="/admin/categories" class="btn-secondary">Cancel</a>
     </form>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/categories/index.php
+++ b/app/Views/admin/categories/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <div class="card-header">
         <h1>Service Categories</h1>
@@ -39,4 +38,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/categories/index.php
+++ b/app/Views/admin/categories/index.php
@@ -1,0 +1,42 @@
+<?php ob_start(); ?>
+<section class="card">
+    <div class="card-header">
+        <h1>Service Categories</h1>
+        <a class="btn-primary" href="/admin/categories/create">New Category</a>
+    </div>
+    <form class="form-inline" method="GET">
+        <input type="text" name="q" placeholder="Search" value="<?= htmlspecialchars($_GET['q'] ?? '', ENT_QUOTES) ?>">
+        <select name="status">
+            <option value="">All statuses</option>
+            <option value="active" <?= (($_GET['status'] ?? '') === 'active') ? 'selected' : '' ?>>Active</option>
+            <option value="suspended" <?= (($_GET['status'] ?? '') === 'suspended') ? 'selected' : '' ?>>Suspended</option>
+        </select>
+        <button type="submit" class="btn-secondary">Filter</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($categories as $category): ?>
+                <tr>
+                    <td><?= htmlspecialchars($category->name, ENT_QUOTES) ?></td>
+                    <td><span class="tag tag-<?= $category->status ?>"><?= htmlspecialchars($category->status, ENT_QUOTES) ?></span></td>
+                    <td class="actions">
+                        <a href="/admin/categories/<?= $category->id ?>">View</a>
+                        <a href="/admin/categories/<?= $category->id ?>/edit">Edit</a>
+                        <form method="POST" action="/admin/categories/<?= $category->id ?>/delete">
+                            <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES) ?>">
+                            <button type="submit" class="link">Suspend</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/categories/show.php
+++ b/app/Views/admin/categories/show.php
@@ -1,0 +1,10 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($category->name, ENT_QUOTES) ?></h1>
+    <dl class="definition-list">
+        <dt>Status</dt><dd><?= htmlspecialchars($category->status, ENT_QUOTES) ?></dd>
+        <dt>Created</dt><dd><?= htmlspecialchars($category->created_at, ENT_QUOTES) ?></dd>
+    </dl>
+    <a href="/admin/categories" class="btn-secondary">Back</a>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/categories/show.php
+++ b/app/Views/admin/categories/show.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($category->name, ENT_QUOTES) ?></h1>
     <dl class="definition-list">
@@ -7,4 +6,3 @@
     </dl>
     <a href="/admin/categories" class="btn-secondary">Back</a>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/profiles/form.php
+++ b/app/Views/admin/profiles/form.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($title, ENT_QUOTES) ?></h1>
     <form method="POST" action="<?= isset($profile) ? '/admin/profiles/' . $profile->id : '/admin/profiles' ?>" class="form">
@@ -19,4 +18,3 @@
         <a href="/admin/profiles" class="btn-secondary">Cancel</a>
     </form>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/profiles/form.php
+++ b/app/Views/admin/profiles/form.php
@@ -1,0 +1,22 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($title, ENT_QUOTES) ?></h1>
+    <form method="POST" action="<?= isset($profile) ? '/admin/profiles/' . $profile->id : '/admin/profiles' ?>" class="form">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken ?? '', ENT_QUOTES) ?>">
+        <label>Role
+            <input type="text" name="role" value="<?= htmlspecialchars($profile->role ?? '', ENT_QUOTES) ?>" required>
+        </label>
+        <label>Description
+            <textarea name="description" required><?= htmlspecialchars($profile->description ?? '', ENT_QUOTES) ?></textarea>
+        </label>
+        <label>Status
+            <select name="status">
+                <option value="active" <?= isset($profile) && $profile->status === 'active' ? 'selected' : '' ?>>Active</option>
+                <option value="suspended" <?= isset($profile) && $profile->status === 'suspended' ? 'selected' : '' ?>>Suspended</option>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/admin/profiles" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/profiles/index.php
+++ b/app/Views/admin/profiles/index.php
@@ -1,0 +1,35 @@
+<?php ob_start(); ?>
+<section class="card">
+    <div class="card-header">
+        <h1>User Profiles</h1>
+        <a class="btn-primary" href="/admin/profiles/create">New Profile</a>
+    </div>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Role</th>
+                <th>Description</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($profiles as $profile): ?>
+                <tr>
+                    <td><?= htmlspecialchars($profile->role, ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($profile->description, ENT_QUOTES) ?></td>
+                    <td><span class="tag tag-<?= $profile->status ?>"><?= htmlspecialchars($profile->status, ENT_QUOTES) ?></span></td>
+                    <td class="actions">
+                        <a href="/admin/profiles/<?= $profile->id ?>">View</a>
+                        <a href="/admin/profiles/<?= $profile->id ?>/edit">Edit</a>
+                        <form method="POST" action="/admin/profiles/<?= $profile->id ?>/suspend">
+                            <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES) ?>">
+                            <button type="submit" class="link">Suspend</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/profiles/index.php
+++ b/app/Views/admin/profiles/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <div class="card-header">
         <h1>User Profiles</h1>
@@ -32,4 +31,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/profiles/show.php
+++ b/app/Views/admin/profiles/show.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($profile->role, ENT_QUOTES) ?></h1>
     <dl class="definition-list">
@@ -8,4 +7,3 @@
     </dl>
     <a href="/admin/profiles" class="btn-secondary">Back</a>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/profiles/show.php
+++ b/app/Views/admin/profiles/show.php
@@ -1,0 +1,11 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($profile->role, ENT_QUOTES) ?></h1>
+    <dl class="definition-list">
+        <dt>Description</dt><dd><?= htmlspecialchars($profile->description, ENT_QUOTES) ?></dd>
+        <dt>Status</dt><dd><?= htmlspecialchars($profile->status, ENT_QUOTES) ?></dd>
+        <dt>Created</dt><dd><?= htmlspecialchars($profile->created_at, ENT_QUOTES) ?></dd>
+    </dl>
+    <a href="/admin/profiles" class="btn-secondary">Back</a>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/users/form.php
+++ b/app/Views/admin/users/form.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($title, ENT_QUOTES) ?></h1>
     <form method="POST" action="<?= isset($user) ? '/admin/users/' . $user->id : '/admin/users' ?>" class="form">
@@ -37,4 +36,3 @@
         <a href="/admin/users" class="btn-secondary">Cancel</a>
     </form>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/users/form.php
+++ b/app/Views/admin/users/form.php
@@ -1,0 +1,40 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($title, ENT_QUOTES) ?></h1>
+    <form method="POST" action="<?= isset($user) ? '/admin/users/' . $user->id : '/admin/users' ?>" class="form">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken ?? '', ENT_QUOTES) ?>">
+        <label>Name
+            <input type="text" name="name" value="<?= htmlspecialchars($user->name ?? '', ENT_QUOTES) ?>" required>
+        </label>
+        <label>Email
+            <input type="email" name="email" value="<?= htmlspecialchars($user->email ?? '', ENT_QUOTES) ?>" required>
+        </label>
+        <?php if (empty($user)): ?>
+            <label>Password
+                <input type="password" name="password" required>
+            </label>
+        <?php else: ?>
+            <label>New Password (leave blank to keep current)
+                <input type="password" name="password">
+            </label>
+        <?php endif; ?>
+        <label>Profile
+            <select name="profile_id" required>
+                <?php foreach ($profiles as $profile): ?>
+                    <option value="<?= $profile->id ?>" <?= isset($user) && $user->profile_id === $profile->id ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($profile->role, ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label>Status
+            <select name="status">
+                <option value="active" <?= isset($user) && $user->status === 'active' ? 'selected' : '' ?>>Active</option>
+                <option value="suspended" <?= isset($user) && $user->status === 'suspended' ? 'selected' : '' ?>>Suspended</option>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/admin/users" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/users/index.php
+++ b/app/Views/admin/users/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <div class="card-header">
         <h1>User Accounts</h1>
@@ -38,4 +37,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/users/index.php
+++ b/app/Views/admin/users/index.php
@@ -1,0 +1,41 @@
+<?php ob_start(); ?>
+<section class="card">
+    <div class="card-header">
+        <h1>User Accounts</h1>
+        <a class="btn-primary" href="/admin/users/create">New User</a>
+    </div>
+    <form class="form-inline" method="GET">
+        <input type="text" name="q" placeholder="Search email or name" value="<?= htmlspecialchars($_GET['q'] ?? '', ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Search</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Status</th>
+                <th>Role</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($users as $user): ?>
+                <tr>
+                    <td><?= htmlspecialchars($user->name, ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($user->email, ENT_QUOTES) ?></td>
+                    <td><span class="tag tag-<?= $user->status ?>"><?= htmlspecialchars($user->status, ENT_QUOTES) ?></span></td>
+                    <td><?= htmlspecialchars($user->profile?->role ?? 'N/A', ENT_QUOTES) ?></td>
+                    <td class="actions">
+                        <a href="/admin/users/<?= $user->id ?>">View</a>
+                        <a href="/admin/users/<?= $user->id ?>/edit">Edit</a>
+                        <form method="POST" action="/admin/users/<?= $user->id ?>/suspend">
+                            <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES) ?>">
+                            <button type="submit" class="link">Suspend</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/users/show.php
+++ b/app/Views/admin/users/show.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($user->name, ENT_QUOTES) ?></h1>
     <dl class="definition-list">
@@ -9,4 +8,3 @@
     </dl>
     <a href="/admin/users" class="btn-secondary">Back</a>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/admin/users/show.php
+++ b/app/Views/admin/users/show.php
@@ -1,0 +1,12 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($user->name, ENT_QUOTES) ?></h1>
+    <dl class="definition-list">
+        <dt>Email</dt><dd><?= htmlspecialchars($user->email, ENT_QUOTES) ?></dd>
+        <dt>Status</dt><dd><?= htmlspecialchars($user->status, ENT_QUOTES) ?></dd>
+        <dt>Role</dt><dd><?= htmlspecialchars($user->profile?->role ?? 'N/A', ENT_QUOTES) ?></dd>
+        <dt>Joined</dt><dd><?= htmlspecialchars($user->created_at, ENT_QUOTES) ?></dd>
+    </dl>
+    <a href="/admin/users" class="btn-secondary">Back</a>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -1,12 +1,4 @@
 <?php
-static $loginTemplateRendered = false;
-if ($loginTemplateRendered) {
-    return;
-}
-$loginTemplateRendered = true;
-
-ob_start();
-
 $availableRoles = $roleOptions ?? [];
 $selectedRole = $selectedRole ?? '';
 $emailValue = $emailValue ?? '';
@@ -35,4 +27,3 @@ $emailValue = $emailValue ?? '';
         <button type="submit" class="btn-primary">Sign in</button>
     </form>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../layouts/app.php'; ?>

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -1,0 +1,38 @@
+<?php
+static $loginTemplateRendered = false;
+if ($loginTemplateRendered) {
+    return;
+}
+$loginTemplateRendered = true;
+
+ob_start();
+
+$availableRoles = $roleOptions ?? [];
+$selectedRole = $selectedRole ?? '';
+$emailValue = $emailValue ?? '';
+?>
+<section class="card">
+    <h1>Sign in</h1>
+    <p class="tagline">Welcome to the CSR Match Platform. Choose your account type to continue.</p>
+    <form method="POST" action="/login" class="form">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken ?? '', ENT_QUOTES) ?>">
+        <label for="role">I am logging in as
+            <select id="role" name="role" required>
+                <option value="" disabled <?= $selectedRole === '' ? 'selected' : '' ?>>Select an account type</option>
+                <?php foreach ($availableRoles as $roleKey => $roleLabel): ?>
+                    <option value="<?= htmlspecialchars((string) $roleKey, ENT_QUOTES) ?>" <?= $selectedRole === $roleKey ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($roleLabel, ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label for="email">Email
+            <input id="email" type="email" name="email" value="<?= htmlspecialchars($emailValue, ENT_QUOTES) ?>" required>
+        </label>
+        <label for="password">Password
+            <input id="password" type="password" name="password" required>
+        </label>
+        <button type="submit" class="btn-primary">Sign in</button>
+    </form>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../layouts/app.php'; ?>

--- a/app/Views/csr/history/index.php
+++ b/app/Views/csr/history/index.php
@@ -1,0 +1,35 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1>Service History</h1>
+    <form class="form-inline" method="GET">
+        <select name="status">
+            <option value="">All statuses</option>
+            <option value="completed" <?= (($_GET['status'] ?? '') === 'completed') ? 'selected' : '' ?>>Completed</option>
+            <option value="in_progress" <?= (($_GET['status'] ?? '') === 'in_progress') ? 'selected' : '' ?>>In progress</option>
+        </select>
+        <input type="date" name="from" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="to" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Filter</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Request</th>
+                <th>Status</th>
+                <th>Matched at</th>
+                <th>Completed</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($history as $item): ?>
+                <tr>
+                    <td>#<?= $item->request_id ?></td>
+                    <td><span class="tag tag-<?= $item->status ?>"><?= htmlspecialchars($item->status, ENT_QUOTES) ?></span></td>
+                    <td><?= htmlspecialchars($item->matched_at, ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($item->completed_at ?? '-', ENT_QUOTES) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/csr/history/index.php
+++ b/app/Views/csr/history/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1>Service History</h1>
     <form class="form-inline" method="GET">
@@ -32,4 +31,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/csr/requests/index.php
+++ b/app/Views/csr/requests/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1>Volunteer Opportunities</h1>
     <form class="form-inline" method="GET">
@@ -40,4 +39,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/csr/requests/index.php
+++ b/app/Views/csr/requests/index.php
@@ -1,0 +1,43 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1>Volunteer Opportunities</h1>
+    <form class="form-inline" method="GET">
+        <input type="text" name="q" placeholder="Keyword" value="<?= htmlspecialchars($filters['q'] ?? '', ENT_QUOTES) ?>">
+        <select name="category_id">
+            <option value="">All categories</option>
+            <?php foreach ($categories as $category): ?>
+                <option value="<?= $category->id ?>" <?= (string)($filters['category_id'] ?? '') === (string)$category->id ? 'selected' : '' ?>>
+                    <?= htmlspecialchars($category->name, ENT_QUOTES) ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <input type="date" name="from" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="to" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Filter</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Location</th>
+                <th>Date</th>
+                <th>Views</th>
+                <th>Shortlisted</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($requests as $requestItem): ?>
+                <tr>
+                    <td><?= htmlspecialchars($requestItem->title, ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($requestItem->location, ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($requestItem->requested_date, ENT_QUOTES) ?></td>
+                    <td><?= $requestItem->views_count ?></td>
+                    <td><?= $requestItem->shortlist_count ?></td>
+                    <td><a href="/csr/requests/<?= $requestItem->id ?>">View</a></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/csr/requests/show.php
+++ b/app/Views/csr/requests/show.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($requestItem->title, ENT_QUOTES) ?></h1>
     <p><?= nl2br(htmlspecialchars($requestItem->description, ENT_QUOTES)) ?></p>
@@ -11,4 +10,3 @@
     </form>
     <a href="/csr/requests" class="btn-secondary">Back</a>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/csr/requests/show.php
+++ b/app/Views/csr/requests/show.php
@@ -1,0 +1,14 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($requestItem->title, ENT_QUOTES) ?></h1>
+    <p><?= nl2br(htmlspecialchars($requestItem->description, ENT_QUOTES)) ?></p>
+    <p><strong>Location:</strong> <?= htmlspecialchars($requestItem->location, ENT_QUOTES) ?></p>
+    <p><strong>Date:</strong> <?= htmlspecialchars($requestItem->requested_date, ENT_QUOTES) ?></p>
+    <p><strong>Views:</strong> <?= $requestItem->views_count ?> | <strong>Shortlists:</strong> <?= $requestItem->shortlist_count ?></p>
+    <form method="POST" action="/csr/requests/<?= $requestItem->id ?>/shortlist">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken ?? '', ENT_QUOTES) ?>">
+        <button type="submit" class="btn-primary">Add to shortlist</button>
+    </form>
+    <a href="/csr/requests" class="btn-secondary">Back</a>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/csr/shortlist/index.php
+++ b/app/Views/csr/shortlist/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1>My Shortlist</h1>
     <table class="table">
@@ -18,4 +17,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/csr/shortlist/index.php
+++ b/app/Views/csr/shortlist/index.php
@@ -1,0 +1,21 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1>My Shortlist</h1>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Request</th>
+                <th>Saved at</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($shortlist as $item): ?>
+                <tr>
+                    <td><a href="/csr/requests/<?= $item->request_id ?>">Request #<?= $item->request_id ?></a></td>
+                    <td><?= htmlspecialchars($item->created_at, ENT_QUOTES) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/layouts/app.php
+++ b/app/Views/layouts/app.php
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($title ?? 'CSR Platform', ENT_QUOTES) ?></title>
+    <link rel="stylesheet" href="/assets/style.css">
+</head>
+<body>
+<header class="top-nav">
+    <div class="container">
+        <div class="brand"><a href="/dashboard">CSR Match Platform</a></div>
+        <nav>
+            <?php if (!empty($authUser)): ?>
+                <a href="/dashboard">Dashboard</a>
+                <?php if ($authUser->profile?->role === 'user_admin'): ?>
+                    <a href="/admin/users">Users</a>
+                    <a href="/admin/profiles">Profiles</a>
+                    <a href="/admin/categories">Categories</a>
+                <?php elseif ($authUser->profile?->role === 'csr_rep'): ?>
+                    <a href="/csr/requests">Opportunities</a>
+                    <a href="/csr/shortlist">Shortlist</a>
+                    <a href="/csr/history">History</a>
+                <?php elseif ($authUser->profile?->role === 'pin'): ?>
+                    <a href="/pin/requests">My Requests</a>
+                    <a href="/pin/history">History</a>
+                <?php elseif ($authUser->profile?->role === 'platform_manager'): ?>
+                    <a href="/admin/categories">Categories</a>
+                    <a href="/reports">Reports</a>
+                <?php endif; ?>
+                <form method="POST" action="/logout" class="logout-form">
+                    <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken ?? '', ENT_QUOTES) ?>">
+                    <button type="submit">Logout</button>
+                </form>
+            <?php else: ?>
+                <a href="/">Sign in</a>
+            <?php endif; ?>
+        </nav>
+    </div>
+</header>
+<main class="container">
+    <?php if (!empty($flash_success)): ?>
+        <div class="alert alert-success"><?= htmlspecialchars($flash_success, ENT_QUOTES) ?></div>
+    <?php endif; ?>
+    <?= $content ?? '' ?>
+</main>
+
+<?php
+$popupMessages = [];
+if (!empty($flash_warning)) {
+    $popupMessages[] = ['level' => 'warning', 'message' => $flash_warning];
+}
+if (!empty($flash_error)) {
+    $popupMessages[] = ['level' => 'error', 'message' => $flash_error];
+}
+?>
+
+<?php foreach ($popupMessages as $index => $popup): ?>
+    <div class="flash-popup-overlay is-visible" data-popup="<?= $index ?>">
+        <div class="flash-popup-card flash-popup-<?= htmlspecialchars($popup['level'], ENT_QUOTES) ?>">
+            <strong class="flash-popup-title">
+                <?= $popup['level'] === 'error' ? 'Action required' : 'Please check' ?>
+            </strong>
+            <p><?= htmlspecialchars($popup['message'], ENT_QUOTES) ?></p>
+            <button type="button" class="flash-popup-close" data-popup-close="<?= $index ?>">Close</button>
+        </div>
+    </div>
+<?php endforeach; ?>
+
+<?php if ($popupMessages !== []): ?>
+    <script>
+        (function () {
+            const closeButtons = document.querySelectorAll('[data-popup-close]');
+            closeButtons.forEach((button) => {
+                button.addEventListener('click', function () {
+                    const key = this.getAttribute('data-popup-close');
+                    const overlay = document.querySelector('[data-popup="' + key + '"]');
+                    if (overlay) {
+                        overlay.classList.add('is-dismissing');
+                        window.setTimeout(() => overlay.remove(), 150);
+                    }
+                });
+            });
+        })();
+    </script>
+<?php endif; ?>
+</body>
+</html>

--- a/app/Views/layouts/dashboard.php
+++ b/app/Views/layouts/dashboard.php
@@ -1,0 +1,26 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1>Welcome, <?= htmlspecialchars($user->name ?? 'Guest', ENT_QUOTES) ?></h1>
+    <p>Your role: <?= htmlspecialchars($user->profile?->role ?? 'N/A', ENT_QUOTES) ?></p>
+    <div class="grid">
+        <?php if ($user && $user->profile?->role === 'user_admin'): ?>
+            <a class="shortcut" href="/admin/users">Manage Users</a>
+            <a class="shortcut" href="/admin/profiles">Manage Profiles</a>
+            <a class="shortcut" href="/admin/categories">Service Categories</a>
+        <?php elseif ($user && $user->profile?->role === 'csr_rep'): ?>
+            <a class="shortcut" href="/csr/requests">Browse Requests</a>
+            <a class="shortcut" href="/csr/shortlist">My Shortlist</a>
+            <a class="shortcut" href="/csr/history">Service History</a>
+        <?php elseif ($user && $user->profile?->role === 'pin'): ?>
+            <a class="shortcut" href="/pin/requests">My Requests</a>
+            <a class="shortcut" href="/pin/requests/create">Create Request</a>
+            <a class="shortcut" href="/pin/history">Completed Matches</a>
+        <?php elseif ($user && $user->profile?->role === 'platform_manager'): ?>
+            <a class="shortcut" href="/admin/categories">Service Categories</a>
+            <a class="shortcut" href="/reports">Generate Reports</a>
+        <?php else: ?>
+            <p>Please contact an administrator for assistance.</p>
+        <?php endif; ?>
+    </div>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/app.php'; ?>

--- a/app/Views/layouts/dashboard.php
+++ b/app/Views/layouts/dashboard.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1>Welcome, <?= htmlspecialchars($user->name ?? 'Guest', ENT_QUOTES) ?></h1>
     <p>Your role: <?= htmlspecialchars($user->profile?->role ?? 'N/A', ENT_QUOTES) ?></p>
@@ -23,4 +22,3 @@
         <?php endif; ?>
     </div>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/app.php'; ?>

--- a/app/Views/pin/history/index.php
+++ b/app/Views/pin/history/index.php
@@ -1,0 +1,35 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1>Completed Matches</h1>
+    <form class="form-inline" method="GET">
+        <select name="status">
+            <option value="">All statuses</option>
+            <option value="completed" <?= (($_GET['status'] ?? '') === 'completed') ? 'selected' : '' ?>>Completed</option>
+            <option value="in_progress" <?= (($_GET['status'] ?? '') === 'in_progress') ? 'selected' : '' ?>>In progress</option>
+        </select>
+        <input type="date" name="from" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="to" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Filter</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Request</th>
+                <th>Status</th>
+                <th>Matched at</th>
+                <th>Completed</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($history as $item): ?>
+                <tr>
+                    <td>#<?= $item->request_id ?></td>
+                    <td><span class="tag tag-<?= $item->status ?>"><?= htmlspecialchars($item->status, ENT_QUOTES) ?></span></td>
+                    <td><?= htmlspecialchars($item->matched_at, ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($item->completed_at ?? '-', ENT_QUOTES) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/pin/history/index.php
+++ b/app/Views/pin/history/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1>Completed Matches</h1>
     <form class="form-inline" method="GET">
@@ -32,4 +31,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/pin/requests/form.php
+++ b/app/Views/pin/requests/form.php
@@ -1,0 +1,39 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($title, ENT_QUOTES) ?></h1>
+    <form method="POST" action="<?= isset($requestItem) ? '/pin/requests/' . $requestItem->id : '/pin/requests' ?>" class="form">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken ?? '', ENT_QUOTES) ?>">
+        <label>Title
+            <input type="text" name="title" value="<?= htmlspecialchars($requestItem->title ?? '', ENT_QUOTES) ?>" required>
+        </label>
+        <label>Description
+            <textarea name="description" required><?= htmlspecialchars($requestItem->description ?? '', ENT_QUOTES) ?></textarea>
+        </label>
+        <label>Location
+            <input type="text" name="location" value="<?= htmlspecialchars($requestItem->location ?? '', ENT_QUOTES) ?>" required>
+        </label>
+        <label>Requested Date
+            <input type="date" name="requested_date" value="<?= htmlspecialchars($requestItem->requested_date ?? '', ENT_QUOTES) ?>" required>
+        </label>
+        <label>Category
+            <select name="category_id" required>
+                <?php foreach ($categories as $category): ?>
+                    <option value="<?= $category->id ?>" <?= isset($requestItem) && $requestItem->category_id === $category->id ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($category->name, ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label>Status
+            <select name="status">
+                <option value="open" <?= isset($requestItem) && $requestItem->status === 'open' ? 'selected' : '' ?>>Open</option>
+                <option value="in_progress" <?= isset($requestItem) && $requestItem->status === 'in_progress' ? 'selected' : '' ?>>In progress</option>
+                <option value="completed" <?= isset($requestItem) && $requestItem->status === 'completed' ? 'selected' : '' ?>>Completed</option>
+                <option value="cancelled" <?= isset($requestItem) && $requestItem->status === 'cancelled' ? 'selected' : '' ?>>Cancelled</option>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/pin/requests" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/pin/requests/form.php
+++ b/app/Views/pin/requests/form.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($title, ENT_QUOTES) ?></h1>
     <form method="POST" action="<?= isset($requestItem) ? '/pin/requests/' . $requestItem->id : '/pin/requests' ?>" class="form">
@@ -36,4 +35,3 @@
         <a href="/pin/requests" class="btn-secondary">Cancel</a>
     </form>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/pin/requests/index.php
+++ b/app/Views/pin/requests/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <div class="card-header">
         <h1>My Requests</h1>
@@ -34,4 +33,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/pin/requests/index.php
+++ b/app/Views/pin/requests/index.php
@@ -1,0 +1,37 @@
+<?php ob_start(); ?>
+<section class="card">
+    <div class="card-header">
+        <h1>My Requests</h1>
+        <a class="btn-primary" href="/pin/requests/create">New Request</a>
+    </div>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Status</th>
+                <th>Views</th>
+                <th>Shortlisted</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($requests as $requestItem): ?>
+                <tr>
+                    <td><?= htmlspecialchars($requestItem->title, ENT_QUOTES) ?></td>
+                    <td><span class="tag tag-<?= $requestItem->status ?>"><?= htmlspecialchars($requestItem->status, ENT_QUOTES) ?></span></td>
+                    <td><?= $requestItem->views_count ?></td>
+                    <td><?= $requestItem->shortlist_count ?></td>
+                    <td class="actions">
+                        <a href="/pin/requests/<?= $requestItem->id ?>">View</a>
+                        <a href="/pin/requests/<?= $requestItem->id ?>/edit">Edit</a>
+                        <form method="POST" action="/pin/requests/<?= $requestItem->id ?>/delete">
+                            <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES) ?>">
+                            <button type="submit" class="link">Cancel</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/pin/requests/show.php
+++ b/app/Views/pin/requests/show.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1><?= htmlspecialchars($requestItem->title, ENT_QUOTES) ?></h1>
     <p><?= nl2br(htmlspecialchars($requestItem->description, ENT_QUOTES)) ?></p>
@@ -11,4 +10,3 @@
     </dl>
     <a href="/pin/requests" class="btn-secondary">Back</a>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/pin/requests/show.php
+++ b/app/Views/pin/requests/show.php
@@ -1,0 +1,14 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1><?= htmlspecialchars($requestItem->title, ENT_QUOTES) ?></h1>
+    <p><?= nl2br(htmlspecialchars($requestItem->description, ENT_QUOTES)) ?></p>
+    <dl class="definition-list">
+        <dt>Status</dt><dd><?= htmlspecialchars($requestItem->status, ENT_QUOTES) ?></dd>
+        <dt>Requested Date</dt><dd><?= htmlspecialchars($requestItem->requested_date, ENT_QUOTES) ?></dd>
+        <dt>Location</dt><dd><?= htmlspecialchars($requestItem->location, ENT_QUOTES) ?></dd>
+        <dt>Views</dt><dd><?= $requestItem->views_count ?></dd>
+        <dt>Shortlisted</dt><dd><?= $requestItem->shortlist_count ?></dd>
+    </dl>
+    <a href="/pin/requests" class="btn-secondary">Back</a>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../../layouts/app.php'; ?>

--- a/app/Views/reports/index.php
+++ b/app/Views/reports/index.php
@@ -1,0 +1,36 @@
+<?php ob_start(); ?>
+<section class="card">
+    <h1>Platform Reports</h1>
+    <form class="form-inline" method="GET">
+        <select name="period">
+            <option value="daily" <?= $period === 'daily' ? 'selected' : '' ?>>Daily</option>
+            <option value="weekly" <?= $period === 'weekly' ? 'selected' : '' ?>>Weekly</option>
+            <option value="monthly" <?= $period === 'monthly' ? 'selected' : '' ?>>Monthly</option>
+        </select>
+        <button type="submit" class="btn-secondary">Refresh</button>
+    </form>
+    <form method="POST" action="/reports/export" class="form-inline">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars($csrfToken ?? '', ENT_QUOTES) ?>">
+        <input type="hidden" name="period" value="<?= htmlspecialchars($period, ENT_QUOTES) ?>">
+        <button type="submit" class="btn-primary">Export CSV</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Period</th>
+                <th>Matches Created</th>
+                <th>Matches Completed</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($rows as $row): ?>
+                <tr>
+                    <td><?= htmlspecialchars($row['period'], ENT_QUOTES) ?></td>
+                    <td><?= $row['matches_created'] ?></td>
+                    <td><?= $row['matches_completed'] ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php $content = ob_get_clean(); include __DIR__.'/../layouts/app.php'; ?>

--- a/app/Views/reports/index.php
+++ b/app/Views/reports/index.php
@@ -1,4 +1,3 @@
-<?php ob_start(); ?>
 <section class="card">
     <h1>Platform Reports</h1>
     <form class="form-inline" method="GET">
@@ -33,4 +32,3 @@
         </tbody>
     </table>
 </section>
-<?php $content = ob_get_clean(); include __DIR__.'/../layouts/app.php'; ?>

--- a/ci/github-actions.yml
+++ b/ci/github-actions.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+      - name: Run tests
+        run: composer test

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "sim/csr-platform",
+  "description": "Minimal CSR matching platform in pure PHP",
+  "type": "project",
+  "require": {
+    "php": "^8.2",
+    "ext-pdo": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5",
+    "fakerphp/faker": "^1.21"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "app/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "App\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "test": "phpunit"
+  }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'name' => 'CSR Match Platform',
+    'env' => getenv('APP_ENV') ?: 'production',
+    'debug' => filter_var(getenv('APP_DEBUG') ?: false, FILTER_VALIDATE_BOOLEAN),
+    'url' => getenv('APP_URL') ?: 'http://localhost',
+    'session_name' => getenv('SESSION_NAME') ?: 'csr_session',
+    'csrf_secret' => getenv('CSRF_SECRET') ?: 'secret-key',
+];

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'dsn' => getenv('DB_DSN') ?: 'pgsql:host=127.0.0.1;port=5432;dbname=csr_platform',
+    'username' => getenv('DB_USERNAME') ?: 'postgres',
+    'password' => getenv('DB_PASSWORD') ?: 'postgres',
+    'options' => [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ],
+];

--- a/config/roles.php
+++ b/config/roles.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    'user_admin' => [
+        'name' => 'User Administrator',
+        'permissions' => [
+            'accounts.manage',
+            'profiles.manage',
+            'audit.view'
+        ],
+    ],
+    'csr_rep' => [
+        'name' => 'CSR Representative',
+        'permissions' => [
+            'requests.view',
+            'shortlist.manage',
+            'history.view'
+        ],
+    ],
+    'pin' => [
+        'name' => 'Person In Need',
+        'permissions' => [
+            'requests.manage',
+            'history.view'
+        ],
+    ],
+    'platform_manager' => [
+        'name' => 'Platform Manager',
+        'permissions' => [
+            'categories.manage',
+            'reports.view'
+        ],
+    ],
+];

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Controllers\LoginController;
+use App\Controllers\LogoutController;
+use App\Controllers\DashboardController;
+use App\Controllers\Admin\UserController as AdminUserController;
+use App\Controllers\Admin\ProfileController as AdminProfileController;
+use App\Controllers\Admin\CategoryController;
+use App\Controllers\CSR\OpportunityController;
+use App\Controllers\CSR\HistoryController as CSRHistoryController;
+use App\Controllers\PIN\RequestController;
+use App\Controllers\PIN\HistoryController as PINHistoryController;
+use App\Controllers\Reports\ReportController;
+
+return function (\App\Core\Router $router) {
+    $router->get('/', [LoginController::class, 'show'])->name('login');
+    $router->post('/login', [LoginController::class, 'submit']);
+    $router->post('/logout', [LogoutController::class, 'handle'])->middleware(['auth', 'csrf']);
+
+    $router->get('/dashboard', [DashboardController::class, 'index'])->middleware('auth');
+
+    $router->group('/admin', function (\App\Core\Router $router) {
+        $router->get('/users', [AdminUserController::class, 'index']);
+        $router->get('/users/create', [AdminUserController::class, 'create']);
+        $router->post('/users', [AdminUserController::class, 'store']);
+        $router->get('/users/{id}', [AdminUserController::class, 'show']);
+        $router->get('/users/{id}/edit', [AdminUserController::class, 'edit']);
+        $router->post('/users/{id}', [AdminUserController::class, 'update']);
+        $router->post('/users/{id}/suspend', [AdminUserController::class, 'suspend']);
+
+        $router->get('/profiles', [AdminProfileController::class, 'index']);
+        $router->get('/profiles/create', [AdminProfileController::class, 'create']);
+        $router->post('/profiles', [AdminProfileController::class, 'store']);
+        $router->get('/profiles/{id}', [AdminProfileController::class, 'show']);
+        $router->get('/profiles/{id}/edit', [AdminProfileController::class, 'edit']);
+        $router->post('/profiles/{id}', [AdminProfileController::class, 'update']);
+        $router->post('/profiles/{id}/suspend', [AdminProfileController::class, 'suspend']);
+
+        $router->resource('categories', CategoryController::class);
+    }, ['auth', 'role:user_admin']);
+
+    $router->group('/csr', function (\App\Core\Router $router) {
+        $router->get('/requests', [OpportunityController::class, 'index']);
+        $router->get('/requests/{id}', [OpportunityController::class, 'show']);
+        $router->post('/requests/{id}/shortlist', [OpportunityController::class, 'shortlist']);
+        $router->get('/shortlist', [OpportunityController::class, 'shortlistIndex']);
+        $router->get('/history', [CSRHistoryController::class, 'index']);
+    }, ['auth', 'role:csr_rep']);
+
+    $router->group('/pin', function (\App\Core\Router $router) {
+        $router->get('/requests', [RequestController::class, 'index']);
+        $router->get('/requests/create', [RequestController::class, 'create']);
+        $router->post('/requests', [RequestController::class, 'store']);
+        $router->get('/requests/{id}', [RequestController::class, 'show']);
+        $router->get('/requests/{id}/edit', [RequestController::class, 'edit']);
+        $router->post('/requests/{id}', [RequestController::class, 'update']);
+        $router->post('/requests/{id}/delete', [RequestController::class, 'destroy']);
+        $router->get('/history', [PINHistoryController::class, 'index']);
+    }, ['auth', 'role:pin']);
+
+    $router->group('/reports', function (\App\Core\Router $router) {
+        $router->get('/', [ReportController::class, 'index']);
+        $router->post('/export', [ReportController::class, 'export']);
+    }, ['auth', 'role:platform_manager']);
+};

--- a/database/migrations/001_create_tables.sql
+++ b/database/migrations/001_create_tables.sql
@@ -1,0 +1,75 @@
+DROP TABLE IF EXISTS audit_logs CASCADE;
+DROP TABLE IF EXISTS matches CASCADE;
+DROP TABLE IF EXISTS shortlists CASCADE;
+DROP TABLE IF EXISTS pin_requests CASCADE;
+DROP TABLE IF EXISTS service_categories CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS profiles CASCADE;
+
+CREATE TABLE profiles (
+    id BIGSERIAL PRIMARY KEY,
+    role VARCHAR(50) NOT NULL,
+    description TEXT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'active',
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
+    profile_id BIGINT NOT NULL REFERENCES profiles(id),
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(150) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'active',
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE service_categories (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'active',
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE pin_requests (
+    id BIGSERIAL PRIMARY KEY,
+    pin_id BIGINT NOT NULL REFERENCES users(id),
+    category_id BIGINT NOT NULL REFERENCES service_categories(id),
+    title VARCHAR(150) NOT NULL,
+    description TEXT NOT NULL,
+    location VARCHAR(150) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'open',
+    requested_date DATE NOT NULL,
+    views_count INTEGER NOT NULL DEFAULT 0,
+    shortlist_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE shortlists (
+    id BIGSERIAL PRIMARY KEY,
+    csr_id BIGINT NOT NULL REFERENCES users(id),
+    request_id BIGINT NOT NULL REFERENCES pin_requests(id),
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uniq_shortlist UNIQUE (csr_id, request_id)
+);
+
+CREATE TABLE matches (
+    id BIGSERIAL PRIMARY KEY,
+    csr_id BIGINT NOT NULL REFERENCES users(id),
+    request_id BIGINT NOT NULL REFERENCES pin_requests(id),
+    status VARCHAR(20) NOT NULL,
+    matched_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    completed_at TIMESTAMP WITHOUT TIME ZONE NULL
+);
+
+CREATE TABLE audit_logs (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    action VARCHAR(120) NOT NULL,
+    payload TEXT,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -1,0 +1,350 @@
+:root {
+    color-scheme: light;
+    font-family: system-ui, sans-serif;
+    --bg: #f5f6f8;
+    --card: #ffffff;
+    --border: #d1d5db;
+    --text: #111827;
+    --primary: #111827;
+    --primary-text: #f9fafb;
+    --secondary: #4b5563;
+    --muted: #6b7280;
+    --surface-muted: #f3f4f6;
+    --alert-dark: #e5e7eb;
+    --alert-light: #f3f4f6;
+    --logout: #dc2626;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+}
+
+a {
+    color: var(--primary);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.top-nav {
+    background: #ffffff;
+    border-bottom: 1px solid var(--border);
+}
+
+.top-nav .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1.5rem;
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.top-nav nav {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.logout-form {
+    display: inline;
+}
+
+.logout-form button {
+    background: var(--logout);
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    font-weight: 600;
+}
+
+.logout-form button:hover {
+    filter: brightness(1.05);
+}
+
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 1.5rem;
+}
+
+.card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 2px 8px rgba(17, 24, 39, 0.05);
+}
+
+.tagline {
+    margin: 0 0 1rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.form,
+.form-inline {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.form-inline {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font: inherit;
+    background: #ffffff;
+    color: var(--text);
+}
+
+input::placeholder,
+textarea::placeholder {
+    color: var(--secondary);
+}
+
+textarea {
+    min-height: 120px;
+}
+
+.btn-primary,
+.btn-secondary,
+.form button,
+.logout-form button,
+.actions form button {
+    font: inherit;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+}
+
+.btn-primary,
+.form button.btn-primary,
+.form button[type="submit"],
+.form-inline button.btn-primary {
+    background: var(--primary);
+    color: var(--primary-text);
+    border: none;
+}
+
+.btn-secondary,
+.form-inline button.btn-secondary,
+.actions .link,
+.form button.btn-secondary {
+    background: transparent;
+    color: var(--secondary);
+    border: 1px solid var(--border);
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+}
+
+.table th {
+    background: var(--surface-muted);
+}
+
+.actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.actions form {
+    display: inline;
+}
+
+.actions form button.link {
+    background: none;
+    border: none;
+    color: var(--secondary);
+    cursor: pointer;
+}
+
+.alert {
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    margin-bottom: 1rem;
+}
+
+.alert-success {
+    background: var(--alert-dark);
+    color: var(--primary);
+}
+
+.alert-error {
+    background: var(--alert-light);
+    color: var(--primary);
+}
+
+.flash-popup-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(17, 24, 39, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    z-index: 1000;
+    transition: opacity 0.15s ease;
+}
+
+.flash-popup-overlay.is-dismissing {
+    opacity: 0;
+}
+
+.flash-popup-card {
+    width: 100%;
+    max-width: 360px;
+    background: #ffffff;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 40px rgba(17, 24, 39, 0.2);
+    padding: 1.5rem;
+    text-align: center;
+}
+
+.flash-popup-title {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 1.05rem;
+    color: var(--text);
+}
+
+.flash-popup-card p {
+    margin: 0;
+    color: var(--secondary);
+    line-height: 1.5;
+}
+
+.flash-popup-close {
+    margin-top: 1.25rem;
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--primary);
+    color: var(--primary-text);
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.flash-popup-close:hover {
+    filter: brightness(1.05);
+}
+
+.flash-popup-error {
+    border-top: 6px solid #b91c1c;
+}
+
+.flash-popup-error p {
+    color: #991b1b;
+}
+
+.flash-popup-warning {
+    border-top: 6px solid #d97706;
+}
+
+.flash-popup-warning p {
+    color: #92400e;
+}
+
+.tag {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    background: #e5e7eb;
+    font-size: 0.85rem;
+    color: var(--secondary);
+}
+
+.tag-active {
+    background: #d1d5db;
+    color: var(--text);
+}
+
+.tag-suspended {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.tag-open {
+    background: #e5e7eb;
+    color: var(--text);
+}
+
+.tag-in_progress {
+    background: #e0e7ff;
+    color: #3730a3;
+}
+
+.tag-completed {
+    background: #dcfce7;
+    color: #047857;
+}
+
+.tag-cancelled {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.shortcut {
+    display: block;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    text-align: center;
+    background: var(--surface-muted);
+    color: var(--text);
+}
+
+.definition-list {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.5rem 1rem;
+}
+
+.definition-list dt {
+    font-weight: 600;
+}
+
+.definition-list dd {
+    margin: 0;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,22 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Core\Application;
+use App\Core\Container;
+
+$envFile = __DIR__ . '/../.env';
+if (file_exists($envFile)) {
+    foreach (file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        if (str_starts_with(trim($line), '#')) {
+            continue;
+        }
+        [$key, $value] = array_map('trim', explode('=', $line, 2));
+        putenv("{$key}={$value}");
+    }
+}
+
+$container = new Container();
+$app = new Application($container);
+$app->bootstrap();
+$app->handle();

--- a/scripts/generate_test_data.php
+++ b/scripts/generate_test_data.php
@@ -1,0 +1,130 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Faker\Factory;
+
+$config = require __DIR__ . '/../config/database.php';
+$pdo = new PDO($config['dsn'], $config['username'], $config['password'], $config['options']);
+$faker = Factory::create();
+
+$pdo->exec('TRUNCATE TABLE audit_logs, matches, shortlists, pin_requests, service_categories, users, profiles RESTART IDENTITY CASCADE');
+
+$profiles = [
+    ['role' => 'user_admin', 'description' => 'User administrator with full account access'],
+    ['role' => 'csr_rep', 'description' => 'Corporate social responsibility representative'],
+    ['role' => 'pin', 'description' => 'Person in need requesting assistance'],
+    ['role' => 'platform_manager', 'description' => 'Platform manager for categories and reports'],
+];
+
+$profileIds = [];
+$now = date('Y-m-d H:i:s');
+$stmtProfile = $pdo->prepare('INSERT INTO profiles (role, description, status, created_at, updated_at) VALUES (:role, :description, :status, :created_at, :updated_at)');
+foreach ($profiles as $profile) {
+    $stmtProfile->execute([
+        'role' => $profile['role'],
+        'description' => $profile['description'],
+        'status' => 'active',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+    $profileIds[$profile['role']] = (int) $pdo->lastInsertId();
+}
+
+$stmtUser = $pdo->prepare('INSERT INTO users (profile_id, name, email, password_hash, status, created_at, updated_at) VALUES (:profile_id, :name, :email, :password_hash, :status, :created_at, :updated_at)');
+
+$accounts = [
+    ['role' => 'user_admin', 'name' => 'Admin One', 'email' => 'admin@example.com'],
+    ['role' => 'csr_rep', 'name' => 'CSR Representative', 'email' => 'csr.rep@example.com'],
+    ['role' => 'pin', 'name' => 'Person In Need', 'email' => 'pin.user@example.com'],
+    ['role' => 'platform_manager', 'name' => 'Platform Manager', 'email' => 'manager@example.com'],
+];
+
+foreach ($accounts as $account) {
+    $stmtUser->execute([
+        'profile_id' => $profileIds[$account['role']],
+        'name' => $account['name'],
+        'email' => $account['email'],
+        'password_hash' => password_hash('password123', PASSWORD_BCRYPT),
+        'status' => 'active',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+}
+
+// Generate additional random users for each profile
+foreach ($profileIds as $role => $id) {
+    for ($i = 0; $i < 30; $i++) {
+        $stmtUser->execute([
+            'profile_id' => $id,
+            'name' => $faker->name(),
+            'email' => $faker->unique()->safeEmail(),
+            'password_hash' => password_hash('password123', PASSWORD_BCRYPT),
+            'status' => $faker->randomElement(['active', 'active', 'suspended']),
+            'created_at' => $faker->dateTimeBetween('-2 years')->format('Y-m-d H:i:s'),
+            'updated_at' => $now,
+        ]);
+    }
+}
+
+$categoryStmt = $pdo->prepare('INSERT INTO service_categories (name, status, created_at, updated_at) VALUES (:name, :status, :created_at, :updated_at)');
+$categoryIds = [];
+for ($i = 0; $i < 20; $i++) {
+    $categoryStmt->execute([
+        'name' => ucfirst($faker->word()) . ' Support',
+        'status' => $faker->randomElement(['active', 'active', 'suspended']),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+    $categoryIds[] = (int) $pdo->lastInsertId();
+}
+
+$pinIds = $pdo->query("SELECT id FROM users WHERE profile_id = {$profileIds['pin']}")->fetchAll(PDO::FETCH_COLUMN);
+$csrIds = $pdo->query("SELECT id FROM users WHERE profile_id = {$profileIds['csr_rep']}")->fetchAll(PDO::FETCH_COLUMN);
+
+$requestStmt = $pdo->prepare('INSERT INTO pin_requests (pin_id, category_id, title, description, location, status, requested_date, views_count, shortlist_count, created_at, updated_at) VALUES (:pin_id, :category_id, :title, :description, :location, :status, :requested_date, :views_count, :shortlist_count, :created_at, :updated_at)');
+
+$requestIds = [];
+for ($i = 0; $i < 120; $i++) {
+    $pinId = (int) $faker->randomElement($pinIds);
+    $status = $faker->randomElement(['open', 'open', 'in_progress', 'completed']);
+    $requestStmt->execute([
+        'pin_id' => $pinId,
+        'category_id' => $faker->randomElement($categoryIds),
+        'title' => ucfirst($faker->words(3, true)),
+        'description' => $faker->paragraph(),
+        'location' => $faker->city(),
+        'status' => $status,
+        'requested_date' => $faker->date(),
+        'views_count' => $faker->numberBetween(0, 250),
+        'shortlist_count' => $faker->numberBetween(0, 50),
+        'created_at' => $faker->dateTimeBetween('-1 years')->format('Y-m-d H:i:s'),
+        'updated_at' => $now,
+    ]);
+    $requestIds[] = (int) $pdo->lastInsertId();
+}
+
+$shortlistStmt = $pdo->prepare('INSERT INTO shortlists (csr_id, request_id, created_at) VALUES (:csr_id, :request_id, :created_at)');
+for ($i = 0; $i < 150; $i++) {
+    $shortlistStmt->execute([
+        'csr_id' => $faker->randomElement($csrIds),
+        'request_id' => $faker->randomElement($requestIds),
+        'created_at' => $faker->dateTimeBetween('-6 months')->format('Y-m-d H:i:s'),
+    ]);
+}
+
+$matchStmt = $pdo->prepare('INSERT INTO matches (csr_id, request_id, status, matched_at, completed_at) VALUES (:csr_id, :request_id, :status, :matched_at, :completed_at)');
+for ($i = 0; $i < 160; $i++) {
+    $status = $faker->randomElement(['in_progress', 'completed']);
+    $matchedAt = $faker->dateTimeBetween('-1 years');
+    $completedAt = $status === 'completed' ? $faker->dateTimeBetween($matchedAt)->format('Y-m-d H:i:s') : null;
+    $matchStmt->execute([
+        'csr_id' => $faker->randomElement($csrIds),
+        'request_id' => $faker->randomElement($requestIds),
+        'status' => $status,
+        'matched_at' => $matchedAt->format('Y-m-d H:i:s'),
+        'completed_at' => $completedAt,
+    ]);
+}
+
+echo "Seed data generated.\n";

--- a/scripts/migrate.php
+++ b/scripts/migrate.php
@@ -1,0 +1,15 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$config = require __DIR__ . '/../config/database.php';
+$pdo = new PDO($config['dsn'], $config['username'], $config['password'], $config['options']);
+
+$migrations = glob(__DIR__ . '/../database/migrations/*.sql');
+foreach ($migrations as $file) {
+    $sql = file_get_contents($file);
+    echo "Running migration: {$file}\n";
+    $pdo->exec($sql);
+}
+
+echo "Migrations complete.\n";

--- a/tests/Feature/MatchRepositoryTest.php
+++ b/tests/Feature/MatchRepositoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Repositories\MatchRepository;
+
+final class MatchRepositoryTest extends TestCase
+{
+    private PDO $pdo;
+    private MatchRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('CREATE TABLE matches (id INTEGER PRIMARY KEY AUTOINCREMENT, csr_id INTEGER, request_id INTEGER, status TEXT, matched_at TEXT, completed_at TEXT)');
+        $this->repository = new MatchRepository($this->pdo);
+    }
+
+    public function testAggregateByPeriodGroupsDailyTotals(): void
+    {
+        $this->pdo->prepare('INSERT INTO matches (csr_id, request_id, status, matched_at, completed_at) VALUES (?,?,?,?,?)')->execute([1, 1, 'completed', '2024-01-01 10:00:00', '2024-01-02 10:00:00']);
+        $this->pdo->prepare('INSERT INTO matches (csr_id, request_id, status, matched_at, completed_at) VALUES (?,?,?,?,?)')->execute([1, 2, 'in_progress', '2024-01-01 12:00:00', null]);
+        $this->pdo->prepare('INSERT INTO matches (csr_id, request_id, status, matched_at, completed_at) VALUES (?,?,?,?,?)')->execute([2, 3, 'completed', '2024-01-03 09:00:00', '2024-01-04 09:00:00']);
+
+        $result = $this->repository->aggregateByPeriod('daily');
+
+        $this->assertCount(2, $result);
+        $this->assertSame('2024-01-03', $result[0]['period']);
+        $this->assertSame(1, $result[0]['matches_created']);
+        $this->assertSame(1, $result[0]['matches_completed']);
+        $this->assertSame('2024-01-01', $result[1]['period']);
+        $this->assertSame(2, $result[1]['matches_created']);
+        $this->assertSame(1, $result[1]['matches_completed']);
+    }
+}

--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Core\Validator;
+
+final class ValidatorTest extends TestCase
+{
+    public function testValidatesRequiredFields(): void
+    {
+        $validator = new Validator();
+        $this->assertFalse($validator->validate(['email' => ''], ['email' => 'required|email']));
+        $this->assertArrayHasKey('email', $validator->errors());
+    }
+
+    public function testPassesWithValidData(): void
+    {
+        $validator = new Validator();
+        $this->assertTrue($validator->validate(['email' => 'user@example.com'], ['email' => 'required|email']));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary
- guard the login template against being rendered twice in a single request so the page only shows one form
- remove the footer copyright markup to keep the monochrome layout clean
- drop the unused footer styles from the shared stylesheet

## Testing
- php -l app/Views/auth/login.php
- php -l app/Views/layouts/app.php

------
https://chatgpt.com/codex/tasks/task_e_68e3a6ca40808331942b05e5adefbde4