### PR TITLE
Refactor admin profiles listing through use case

### DIFF
--- a/app/Controllers/Admin/ProfileController.php
+++ b/app/Controllers/Admin/ProfileController.php
@@ -17,6 +17,7 @@ class ProfileController extends Controller
         \App\Core\Auth $auth,
         private ProfileRepository $profiles,
         private CreateProfileController $createProfileController,
+        private ViewProfilesController $viewProfilesController,
         protected Csrf $csrf
     ) {
         parent::__construct($request, $view, $response, $session, $auth);
@@ -25,10 +26,11 @@ class ProfileController extends Controller
     public function index(): Response
     {
         $page = (int) ($this->request->query()['page'] ?? 1);
-        [$profiles, $total] = $this->profiles->paginate($page, 20, [
+        $filters = [
             'role' => $this->request->query()['role'] ?? null,
             'status' => $this->request->query()['status'] ?? null,
-        ]);
+        ];
+        [$profiles, $total] = $this->viewProfilesController->viewProfiles($filters, $page, 20);
         return $this->render('admin/profiles/index.php', [
             'title' => 'User Profiles',
             'profiles' => $profiles,

--- a/app/Controllers/Admin/ViewProfilesController.php
+++ b/app/Controllers/Admin/ViewProfilesController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Controllers\Admin;
+
+use App\Entities\UserProfile;
+
+class ViewProfilesController
+{
+    public function __construct(private UserProfile $userProfile)
+    {
+    }
+
+    public function viewProfiles(array $filters = [], int $page = 1, int $perPage = 20): array
+    {
+        return $this->userProfile->getUserProfileList($page, $perPage, $filters);
+    }
+}

--- a/app/Entities/UserProfile.php
+++ b/app/Entities/UserProfile.php
@@ -12,6 +12,11 @@ class UserProfile
     {
     }
 
+    public function getUserProfileList(int $page = 1, int $perPage = 20, array $filters = []): array
+    {
+        return $this->profiles->paginate($page, $perPage, $filters);
+    }
+
     public function registerUserProfile(string $role, string $description, string $status = 'active'): bool
     {
         $this->lastError = null;


### PR DESCRIPTION
## Summary
- add a dedicated admin view profiles controller to orchestrate listing
- expose a listing method on the UserProfile entity backed by the repository
- update the HTTP profile controller to retrieve profile data through the new use case

## Testing
- composer test *(fails: phpunit not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f73943d21483319d198e4144808e51