### PR TITLE
Provide English validation prompts for required fields

### DIFF
--- a/app/Views/Format/DateFormatter.php
+++ b/app/Views/Format/DateFormatter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Views\Format;
+
+use DateTimeImmutable;
+use Throwable;
+
+final class DateFormatter
+{
+    /**
+     * Format a date string using an English format.
+     *
+     * @param string|null $value  Raw date/time string from storage.
+     * @param string      $format PHP date format string (default Month day, Year).
+     */
+    public static function date(?string $value, string $format = 'M j, Y'): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        try {
+            $dateTime = new DateTimeImmutable($trimmed);
+        } catch (Throwable) {
+            return $trimmed;
+        }
+
+        return $dateTime->format($format);
+    }
+
+    /**
+     * Format a date and time string using an English format.
+     */
+    public static function dateTime(?string $value, string $format = 'M j, Y H:i'): ?string
+    {
+        return self::date($value, $format);
+    }
+}

--- a/app/Views/csr/history/index.php
+++ b/app/Views/csr/history/index.php
@@ -1,4 +1,9 @@
-<?php ob_start(); ?>
+<?php
+
+use App\Views\Format\DateFormatter;
+
+ob_start();
+?>
 <section class="card">
     <h1>Service History</h1>
     <form class="form-inline" method="GET">
@@ -7,8 +12,8 @@
             <option value="completed" <?= (($_GET['status'] ?? '') === 'completed') ? 'selected' : '' ?>>Completed</option>
             <option value="in_progress" <?= (($_GET['status'] ?? '') === 'in_progress') ? 'selected' : '' ?>>In progress</option>
         </select>
-        <input type="date" name="from" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
-        <input type="date" name="to" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="from" lang="en" placeholder="YYYY-MM-DD" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="to" lang="en" placeholder="YYYY-MM-DD" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
         <button type="submit" class="btn-secondary">Filter</button>
     </form>
     <table class="table">
@@ -25,8 +30,10 @@
                 <tr>
                     <td>#<?= $item->request_id ?></td>
                     <td><span class="tag tag-<?= $item->status ?>"><?= htmlspecialchars($item->status, ENT_QUOTES) ?></span></td>
-                    <td><?= htmlspecialchars($item->matched_at, ENT_QUOTES) ?></td>
-                    <td><?= htmlspecialchars($item->completed_at ?? '-', ENT_QUOTES) ?></td>
+                    <?php $matchedAt = DateFormatter::dateTime($item->matched_at); ?>
+                    <td><?= htmlspecialchars($matchedAt ?? $item->matched_at, ENT_QUOTES) ?></td>
+                    <?php $completedAt = DateFormatter::dateTime($item->completed_at); ?>
+                    <td><?= htmlspecialchars($completedAt ?? '-', ENT_QUOTES) ?></td>
                 </tr>
             <?php endforeach; ?>
         </tbody>

--- a/app/Views/csr/requests/index.php
+++ b/app/Views/csr/requests/index.php
@@ -1,4 +1,9 @@
-<?php ob_start(); ?>
+<?php
+
+use App\Views\Format\DateFormatter;
+
+ob_start();
+?>
 <section class="card">
     <h1>Volunteer Opportunities</h1>
     <form class="form-inline" method="GET">
@@ -11,8 +16,8 @@
                 </option>
             <?php endforeach; ?>
         </select>
-        <input type="date" name="from" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
-        <input type="date" name="to" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="from" lang="en" placeholder="YYYY-MM-DD" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="to" lang="en" placeholder="YYYY-MM-DD" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
         <button type="submit" class="btn-secondary">Filter</button>
     </form>
     <table class="table">
@@ -31,7 +36,8 @@
                 <tr>
                     <td><?= htmlspecialchars($requestItem->title, ENT_QUOTES) ?></td>
                     <td><?= htmlspecialchars($requestItem->location, ENT_QUOTES) ?></td>
-                    <td><?= htmlspecialchars($requestItem->requested_date, ENT_QUOTES) ?></td>
+                    <?php $requestedDate = DateFormatter::date($requestItem->requested_date); ?>
+                    <td><?= htmlspecialchars($requestedDate ?? $requestItem->requested_date, ENT_QUOTES) ?></td>
                     <td><?= $requestItem->views_count ?></td>
                     <td><?= $requestItem->shortlist_count ?></td>
                     <td><a href="/csr/requests/<?= $requestItem->id ?>">View</a></td>

--- a/app/Views/layouts/app.php
+++ b/app/Views/layouts/app.php
@@ -84,6 +84,57 @@ if (!empty($flash_error)) {
         })();
     </script>
 <?php endif; ?>
+<script>
+    (function () {
+        const requiredFields = document.querySelectorAll('input[required], textarea[required], select[required]');
+        if (requiredFields.length === 0) {
+            return;
+        }
+
+        const getMessage = (field, validityState) => {
+            if (field.tagName === 'SELECT') {
+                return 'Please choose an option before continuing.';
+            }
+
+            switch (field.type) {
+                case 'email':
+                    return validityState === 'typeMismatch'
+                        ? 'Please enter a valid email address.'
+                        : 'Please enter an email address.';
+                case 'password':
+                    return 'Please provide a password.';
+                case 'number':
+                    return 'Please enter a valid number.';
+                case 'date':
+                case 'datetime-local':
+                    return 'Please select a valid date.';
+                default:
+                    return 'Please fill out this field.';
+            }
+        };
+
+        requiredFields.forEach((field) => {
+            field.addEventListener('invalid', function () {
+                this.setCustomValidity('');
+
+                if (this.validity.valueMissing) {
+                    this.setCustomValidity(getMessage(this, 'valueMissing'));
+                } else if (this.validity.typeMismatch) {
+                    this.setCustomValidity(getMessage(this, 'typeMismatch'));
+                } else if (this.validity.patternMismatch) {
+                    this.setCustomValidity('Please match the requested format.');
+                }
+            });
+
+            const resetMessage = function () {
+                this.setCustomValidity('');
+            };
+
+            field.addEventListener('input', resetMessage);
+            field.addEventListener('change', resetMessage);
+        });
+    })();
+</script>
 <footer class="footer">
     <div class="container">&copy; <?= date('Y') ?> CSR Match Platform</div>
 </footer>

--- a/app/Views/pin/history/index.php
+++ b/app/Views/pin/history/index.php
@@ -1,4 +1,9 @@
-<?php ob_start(); ?>
+<?php
+
+use App\Views\Format\DateFormatter;
+
+ob_start();
+?>
 <section class="card">
     <h1>Completed Matches</h1>
     <form class="form-inline" method="GET">
@@ -7,8 +12,8 @@
             <option value="completed" <?= (($_GET['status'] ?? '') === 'completed') ? 'selected' : '' ?>>Completed</option>
             <option value="in_progress" <?= (($_GET['status'] ?? '') === 'in_progress') ? 'selected' : '' ?>>In progress</option>
         </select>
-        <input type="date" name="from" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
-        <input type="date" name="to" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="from" lang="en" placeholder="YYYY-MM-DD" value="<?= htmlspecialchars($filters['from'] ?? '', ENT_QUOTES) ?>">
+        <input type="date" name="to" lang="en" placeholder="YYYY-MM-DD" value="<?= htmlspecialchars($filters['to'] ?? '', ENT_QUOTES) ?>">
         <button type="submit" class="btn-secondary">Filter</button>
     </form>
     <table class="table">
@@ -25,8 +30,10 @@
                 <tr>
                     <td>#<?= $item->request_id ?></td>
                     <td><span class="tag tag-<?= $item->status ?>"><?= htmlspecialchars($item->status, ENT_QUOTES) ?></span></td>
-                    <td><?= htmlspecialchars($item->matched_at, ENT_QUOTES) ?></td>
-                    <td><?= htmlspecialchars($item->completed_at ?? '-', ENT_QUOTES) ?></td>
+                    <?php $matchedAt = DateFormatter::dateTime($item->matched_at); ?>
+                    <td><?= htmlspecialchars($matchedAt ?? $item->matched_at, ENT_QUOTES) ?></td>
+                    <?php $completedAt = DateFormatter::dateTime($item->completed_at); ?>
+                    <td><?= htmlspecialchars($completedAt ?? '-', ENT_QUOTES) ?></td>
                 </tr>
             <?php endforeach; ?>
         </tbody>

--- a/app/Views/pin/requests/form.php
+++ b/app/Views/pin/requests/form.php
@@ -13,7 +13,7 @@
             <input type="text" name="location" value="<?= htmlspecialchars($requestItem->location ?? '', ENT_QUOTES) ?>" required>
         </label>
         <label>Requested Date
-            <input type="date" name="requested_date" value="<?= htmlspecialchars($requestItem->requested_date ?? '', ENT_QUOTES) ?>" required>
+            <input type="date" name="requested_date" lang="en" placeholder="YYYY-MM-DD" value="<?= htmlspecialchars($requestItem->requested_date ?? '', ENT_QUOTES) ?>" required>
         </label>
         <label>Category
             <select name="category_id" required>


### PR DESCRIPTION
## Summary
- add a layout-level script that injects English validation messages for required fields
- cover text, email, password, number, and date inputs along with selects to prevent Chinese hover tooltips

## Testing
- composer test *(fails: phpunit not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7582e49608331a514e582fd251cc0