### PR TITLE
Refactor: rebuild BCE PHP skeleton

### DIFF
--- a/csit314-csr-platform/README.md
+++ b/csit314-csr-platform/README.md
@@ -1,0 +1,50 @@
+# CSR Match Platform (Boundary-Control-Entity Skeleton)
+
+This directory contains a pure PHP implementation of the CSR platform using the Boundary–Control–Entity paradigm.
+All pages are implemented as boundary scripts that orchestrate controllers and entities without any framework dependencies.
+
+## Getting Started
+
+1. **Install PHP 8.2+** with the SQLite PDO extension enabled.
+2. **Seed the database**
+   ```bash
+   php scripts/generate-test-data.php
+   ```
+3. **Run the development server**
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+4. Navigate to `http://localhost:8000/public/index.php` and sign in using one of the seeded accounts:
+
+| Role | Email | Password |
+| ---- | ----- | -------- |
+| User Admin | admin@example.com | password123 |
+| CSR Rep | csr.rep@example.com | password123 |
+| Person In Need | pin.user@example.com | password123 |
+| Platform Manager | manager@example.com | password123 |
+
+## Project Layout
+
+The repository follows a module-first BCE structure:
+
+```
+csit314-csr-platform/
+├── config/               # Application configuration
+├── public/               # Front controller and static assets
+├── src/                  # Boundary/Controller/Entity implementations
+│   ├── admin/
+│   ├── csr-representative/
+│   ├── pin/
+│   ├── PM/
+│   ├── login/
+│   └── shared/
+├── scripts/              # CLI utilities
+├── storage/              # SQLite database and logs
+└── create_data_table.sql # Schema definition
+```
+
+## Notes
+
+- Each boundary script owns its logout handler (`logout()`) and renders HTML matching the migrated views.
+- Controllers encapsulate validation and persistence, returning scalar results for the boundary to interpret.
+- Entities interact directly with the SQLite database via PDO.

--- a/csit314-csr-platform/config/application.php
+++ b/csit314-csr-platform/config/application.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'base_path' => dirname(__DIR__),
+    'session_name' => 'csr_platform_session',
+];

--- a/csit314-csr-platform/config/ci-cd/README.md
+++ b/csit314-csr-platform/config/ci-cd/README.md
@@ -1,0 +1,4 @@
+# CI/CD Notes
+
+This directory is reserved for pipeline configuration files (GitHub Actions, GitLab CI, etc.).
+Add your workflow definitions here when integrating with automation tooling.

--- a/csit314-csr-platform/config/database.php
+++ b/csit314-csr-platform/config/database.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'dsn' => getenv('CSR_PLATFORM_DSN') ?: 'sqlite:' . __DIR__ . '/../storage/csr_platform.sqlite',
+    'username' => getenv('CSR_PLATFORM_DB_USER') ?: null,
+    'password' => getenv('CSR_PLATFORM_DB_PASS') ?: null,
+];

--- a/csit314-csr-platform/create_data_table.sql
+++ b/csit314-csr-platform/create_data_table.sql
@@ -1,0 +1,77 @@
+PRAGMA foreign_keys = OFF;
+DROP TABLE IF EXISTS audit_logs;
+DROP TABLE IF EXISTS matches;
+DROP TABLE IF EXISTS shortlists;
+DROP TABLE IF EXISTS pin_requests;
+DROP TABLE IF EXISTS service_categories;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS profiles;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE profiles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    role TEXT NOT NULL,
+    description TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile_id INTEGER NOT NULL REFERENCES profiles(id),
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    password TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE service_categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pin_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pin_id INTEGER NOT NULL REFERENCES users(id),
+    category_id INTEGER NOT NULL REFERENCES service_categories(id),
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    location TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open',
+    requested_date TEXT NOT NULL,
+    views_count INTEGER NOT NULL DEFAULT 0,
+    shortlist_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE shortlists (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    csr_id INTEGER NOT NULL REFERENCES users(id),
+    request_id INTEGER NOT NULL REFERENCES pin_requests(id),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (csr_id, request_id)
+);
+
+CREATE TABLE matches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    csr_id INTEGER NOT NULL REFERENCES users(id),
+    request_id INTEGER NOT NULL REFERENCES pin_requests(id),
+    status TEXT NOT NULL,
+    matched_at TEXT NOT NULL,
+    completed_at TEXT NULL
+);
+
+CREATE TABLE audit_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    action TEXT NOT NULL,
+    payload TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/csit314-csr-platform/public/css/style.css
+++ b/csit314-csr-platform/public/css/style.css
@@ -1,0 +1,371 @@
+:root {
+    color-scheme: light;
+    font-family: system-ui, sans-serif;
+    --bg: #f5f6f8;
+    --card: #ffffff;
+    --border: #d1d5db;
+    --text: #111827;
+    --primary: #111827;
+    --primary-text: #f9fafb;
+    --secondary: #4b5563;
+    --muted: #6b7280;
+    --surface-muted: #f3f4f6;
+    --alert-dark: #e5e7eb;
+    --alert-light: #f3f4f6;
+    --logout: #dc2626;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+}
+
+a {
+    color: var(--primary);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.top-nav {
+    background: #ffffff;
+    border-bottom: 1px solid var(--border);
+}
+
+.top-nav .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1.5rem;
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.top-nav nav {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.logout-form {
+    display: inline;
+}
+
+.logout-form button {
+    background: var(--logout);
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    font-weight: 600;
+}
+
+.logout-form button:hover {
+    filter: brightness(1.05);
+}
+
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 1.5rem;
+}
+
+.card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 2px 8px rgba(17, 24, 39, 0.05);
+}
+
+.tagline {
+    margin: 0 0 1rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.form,
+.form-inline {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.form-inline {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font: inherit;
+    background: #ffffff;
+    color: var(--text);
+}
+
+input::placeholder,
+textarea::placeholder {
+    color: var(--secondary);
+}
+
+textarea {
+    min-height: 120px;
+}
+
+.btn-primary,
+.btn-secondary,
+.form button,
+.logout-form button,
+.actions form button {
+    font: inherit;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+}
+
+.btn-primary,
+.form button.btn-primary,
+.form button[type="submit"],
+.form-inline button.btn-primary {
+    background: var(--primary);
+    color: var(--primary-text);
+    border: none;
+}
+
+.btn-secondary,
+.form-inline button.btn-secondary,
+.actions .link,
+.form button.btn-secondary {
+    background: transparent;
+    color: var(--secondary);
+    border: 1px solid var(--border);
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    vertical-align: middle;
+}
+
+.table th {
+    background: var(--surface-muted);
+}
+
+.table th.status-col,
+.table td.status-col {
+    text-align: center;
+    white-space: nowrap;
+    width: 1%;
+}
+
+.table th.actions,
+.table td.actions {
+    text-align: right;
+    white-space: nowrap;
+    width: 1%;
+}
+
+.table td.actions > * + * {
+    margin-left: 0.5rem;
+}
+
+.table td.actions form {
+    display: inline;
+    margin: 0;
+}
+
+.table td.actions form button.link {
+    background: none;
+    border: none;
+    color: var(--secondary);
+    cursor: pointer;
+}
+
+.alert {
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    margin-bottom: 1rem;
+}
+
+.alert-success {
+    background: var(--alert-dark);
+    color: var(--primary);
+}
+
+.alert-error {
+    background: var(--alert-light);
+    color: var(--primary);
+}
+
+.flash-popup-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(17, 24, 39, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    z-index: 1000;
+    transition: opacity 0.15s ease;
+}
+
+.flash-popup-overlay.is-dismissing {
+    opacity: 0;
+}
+
+.flash-popup-card {
+    width: 100%;
+    max-width: 360px;
+    background: #ffffff;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 40px rgba(17, 24, 39, 0.2);
+    padding: 1.5rem;
+    text-align: center;
+}
+
+.flash-popup-title {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 1.05rem;
+    color: var(--text);
+}
+
+.flash-popup-card p {
+    margin: 0;
+    color: var(--secondary);
+    line-height: 1.5;
+}
+
+.flash-popup-close {
+    margin-top: 1.25rem;
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--primary);
+    color: var(--primary-text);
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.flash-popup-close:hover {
+    filter: brightness(1.05);
+}
+
+.flash-popup-error {
+    border-top: 6px solid #b91c1c;
+}
+
+.flash-popup-error p {
+    color: #991b1b;
+}
+
+.flash-popup-warning {
+    border-top: 6px solid #d97706;
+}
+
+.flash-popup-warning p {
+    color: #92400e;
+}
+
+.tag {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    background: #e5e7eb;
+    font-size: 0.85rem;
+    color: var(--secondary);
+}
+
+.tag-active {
+    background: #d1d5db;
+    color: var(--text);
+}
+
+.tag-suspended {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.tag-open {
+    background: #e5e7eb;
+    color: var(--text);
+}
+
+.tag-in_progress {
+    background: #e0e7ff;
+    color: #3730a3;
+}
+
+.tag-completed {
+    background: #dcfce7;
+    color: #047857;
+}
+
+.tag-cancelled {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.shortcut {
+    display: block;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    text-align: center;
+    background: var(--surface-muted);
+    color: var(--text);
+}
+
+.definition-list {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.5rem 1rem;
+}
+
+.definition-list dt {
+    font-weight: 600;
+}
+
+.definition-list dd {
+    margin: 0;
+}
+
+.footer {
+    padding: 1rem 0;
+    border-top: 1px solid var(--border);
+    margin-top: 2rem;
+    text-align: center;
+}

--- a/csit314-csr-platform/public/index.php
+++ b/csit314-csr-platform/public/index.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+$routes = [
+    'login' => __DIR__ . '/../src/login/boundary/loginUI.php',
+    'dashboard' => __DIR__ . '/../src/shared/boundary/DashboardUI.php',
+    'admin/view-accounts' => __DIR__ . '/../src/admin/boundary/ViewAccountsUI.php',
+    'admin/create-account' => __DIR__ . '/../src/admin/boundary/CreateAccountUI.php',
+    'admin/update-account' => __DIR__ . '/../src/admin/boundary/UpdateAccountUI.php',
+    'admin/view-profiles' => __DIR__ . '/../src/admin/boundary/ViewProfilesUI.php',
+    'admin/create-profile' => __DIR__ . '/../src/admin/boundary/CreateProfileUI.php',
+    'csr/search-requests' => __DIR__ . '/../src/csr-representative/boundary/SearchRequestUI.php',
+    'csr/shortlist' => __DIR__ . '/../src/csr-representative/boundary/ViewShortlistedRequestUI.php',
+    'csr/history' => __DIR__ . '/../src/csr-representative/boundary/ViewCSRHistoryUI.php',
+    'csr/view-request' => __DIR__ . '/../src/csr-representative/boundary/ViewRequestDetailUI.php',
+    'pin/my-requests' => __DIR__ . '/../src/pin/boundary/SearchPostedRequestsUI.php',
+    'pin/create-request' => __DIR__ . '/../src/pin/boundary/CreateRequestUI.php',
+    'pin/view-request' => __DIR__ . '/../src/pin/boundary/ViewRequestUI.php',
+    'pin/history' => __DIR__ . '/../src/pin/boundary/ViewPINHistoryUI.php',
+    'pm/categories' => __DIR__ . '/../src/PM/boundary/ViewServiceCategoryUI.php',
+    'pm/update-category' => __DIR__ . '/../src/PM/boundary/UpdateServiceCategoryUI.php',
+    'pm/daily-report' => __DIR__ . '/../src/PM/boundary/GenerateDailyReportUI.php',
+    'pm/weekly-report' => __DIR__ . '/../src/PM/boundary/GenerateWeeklyReportUI.php',
+];
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+$route = $_GET['route'] ?? null;
+
+if (!$route) {
+    if (isset($_SESSION['user'])) {
+        $route = 'dashboard';
+    } else {
+        $route = 'login';
+    }
+}
+
+if (!isset($routes[$route])) {
+    http_response_code(404);
+    echo '<h1>404 Not Found</h1>';
+    exit();
+}
+
+require $routes[$route];

--- a/csit314-csr-platform/scripts/deployment/README.md
+++ b/csit314-csr-platform/scripts/deployment/README.md
@@ -1,0 +1,3 @@
+# Deployment Scripts
+
+Add environment-specific deployment helpers or provisioning scripts to this directory.

--- a/csit314-csr-platform/scripts/generate-test-data.php
+++ b/csit314-csr-platform/scripts/generate-test-data.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/shared/bootstrap.php';
+
+echo "Database seeded with sample data." . PHP_EOL;

--- a/csit314-csr-platform/src/PM/boundary/GenerateDailyReportUI.php
+++ b/csit314-csr-platform/src/PM/boundary/GenerateDailyReportUI.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/generateDailyReportController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$controller = new GenerateDailyReportController();
+$data = $controller->generate($_POST ?: $_GET);
+?>
+<section class="card">
+    <h1>Daily Request Report</h1>
+    <form class="form-inline" method="GET" action="/public/index.php">
+        <input type="hidden" name="route" value="pm/daily-report">
+        <input type="date" name="date" value="<?= htmlspecialchars($data['date'] ?? date('Y-m-d'), ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Refresh</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Total Requests</th>
+                <th>Open</th>
+                <th>Matched</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><?= htmlspecialchars($data['date'] ?? '', ENT_QUOTES) ?></td>
+                <td><?= (int) ($data['total_requests'] ?? 0) ?></td>
+                <td><?= (int) ($data['open_requests'] ?? 0) ?></td>
+                <td><?= (int) ($data['matched_requests'] ?? 0) ?></td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/PM/boundary/GenerateWeeklyReportUI.php
+++ b/csit314-csr-platform/src/PM/boundary/GenerateWeeklyReportUI.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/generateWeeklyReportController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$controller = new GenerateWeeklyReportController();
+$data = $controller->generate($_POST ?: $_GET);
+?>
+<section class="card">
+    <h1>Weekly Request Report</h1>
+    <form class="form-inline" method="GET" action="/public/index.php">
+        <input type="hidden" name="route" value="pm/weekly-report">
+        <input type="date" name="week_start" value="<?= htmlspecialchars($data['week_start'] ?? date('Y-m-d'), ENT_QUOTES) ?>">
+        <input type="date" name="week_end" value="<?= htmlspecialchars($data['week_end'] ?? date('Y-m-d'), ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Refresh</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Week Start</th>
+                <th>Week End</th>
+                <th>Open</th>
+                <th>Matched</th>
+                <th>Completed</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><?= htmlspecialchars($data['week_start'] ?? '', ENT_QUOTES) ?></td>
+                <td><?= htmlspecialchars($data['week_end'] ?? '', ENT_QUOTES) ?></td>
+                <td><?= (int) ($data['open_requests'] ?? 0) ?></td>
+                <td><?= (int) ($data['matched_requests'] ?? 0) ?></td>
+                <td><?= (int) ($data['completed_requests'] ?? 0) ?></td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/PM/boundary/UpdateServiceCategoryUI.php
+++ b/csit314-csr-platform/src/PM/boundary/UpdateServiceCategoryUI.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/updateServiceCategoryController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+$controller = new UpdateServiceCategoryController();
+$category = $id ? $controller->find($id) : null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $id) {
+    if ($controller->update($id, $_POST)) {
+        header('Location: /public/index.php?route=pm/categories');
+        exit();
+    }
+}
+?>
+<section class="card">
+    <h1>Edit Category</h1>
+    <?php if (!empty($_SESSION['category_message'])): ?>
+        <div class="alert alert-info"><?= htmlspecialchars($_SESSION['category_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['category_message']); ?>
+    <?php endif; ?>
+    <form method="POST" action="/public/index.php?route=pm/update-category&id=<?= (int) $id ?>" class="form">
+        <label>Name
+            <input type="text" name="name" value="<?= htmlspecialchars($category['name'] ?? '', ENT_QUOTES) ?>" required>
+        </label>
+        <label>Status
+            <select name="status">
+                <option value="active" <?= (($category['status'] ?? '') === 'active') ? 'selected' : '' ?>>Active</option>
+                <option value="suspended" <?= (($category['status'] ?? '') === 'suspended') ? 'selected' : '' ?>>Suspended</option>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/public/index.php?route=pm/categories" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/PM/boundary/ViewServiceCategoryUI.php
+++ b/csit314-csr-platform/src/PM/boundary/ViewServiceCategoryUI.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/viewServiceCategoryController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$controller = new ViewServiceCategoryController();
+$categories = $controller->list();
+?>
+<section class="card">
+    <div class="card-header">
+        <h1>Service Categories</h1>
+    </div>
+    <?php if (!empty($_SESSION['category_message'])): ?>
+        <div class="alert alert-info"><?= htmlspecialchars($_SESSION['category_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['category_message']); ?>
+    <?php endif; ?>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th class="status-col">Status</th>
+                <th class="actions">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($categories as $category): ?>
+                <tr>
+                    <td><?= htmlspecialchars($category['name'] ?? '', ENT_QUOTES) ?></td>
+                    <td class="status-col"><span class="tag tag-<?= htmlspecialchars($category['status'] ?? '', ENT_QUOTES) ?>"><?= htmlspecialchars($category['status'] ?? '', ENT_QUOTES) ?></span></td>
+                    <td class="actions">
+                        <a href="/public/index.php?route=pm/update-category&id=<?= (int) ($category['id'] ?? 0) ?>">Edit</a>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/PM/controller/generateDailyReportController.php
+++ b/csit314-csr-platform/src/PM/controller/generateDailyReportController.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use shared\database\DatabaseConnection;
+use shared\utils\Validation;
+
+class GenerateDailyReportController
+{
+    public function generate(array $input): array
+    {
+        $date = Validation::sanitizeString($input['date'] ?? date('Y-m-d'));
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT COUNT(*) AS total, SUM(CASE WHEN status = "open" THEN 1 ELSE 0 END) AS open_count,
+            SUM(CASE WHEN status = "matched" THEN 1 ELSE 0 END) AS matched_count
+            FROM pin_requests WHERE requested_date = :date');
+        $stmt->execute([':date' => $date]);
+        $data = $stmt->fetch();
+        return [
+            'date' => $date,
+            'total_requests' => (int) ($data['total'] ?? 0),
+            'open_requests' => (int) ($data['open_count'] ?? 0),
+            'matched_requests' => (int) ($data['matched_count'] ?? 0),
+        ];
+    }
+}

--- a/csit314-csr-platform/src/PM/controller/generateWeeklyReportController.php
+++ b/csit314-csr-platform/src/PM/controller/generateWeeklyReportController.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+use shared\database\DatabaseConnection;
+use shared\utils\Validation;
+
+class GenerateWeeklyReportController
+{
+    public function generate(array $input): array
+    {
+        $weekStart = Validation::sanitizeString($input['week_start'] ?? date('Y-m-d', strtotime('monday this week')));
+        $weekEnd = Validation::sanitizeString($input['week_end'] ?? date('Y-m-d', strtotime('sunday this week')));
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT status, COUNT(*) AS total FROM pin_requests
+            WHERE requested_date BETWEEN :start AND :end GROUP BY status');
+        $stmt->execute([':start' => $weekStart, ':end' => $weekEnd]);
+        $rows = $stmt->fetchAll();
+        $summary = ['open' => 0, 'matched' => 0, 'completed' => 0];
+        foreach ($rows as $row) {
+            $status = strtolower((string) $row['status']);
+            $summary[$status] = (int) $row['total'];
+        }
+
+        return [
+            'week_start' => $weekStart,
+            'week_end' => $weekEnd,
+            'open_requests' => $summary['open'] ?? 0,
+            'matched_requests' => $summary['matched'] ?? 0,
+            'completed_requests' => $summary['completed'] ?? 0,
+        ];
+    }
+}

--- a/csit314-csr-platform/src/PM/controller/updateServiceCategoryController.php
+++ b/csit314-csr-platform/src/PM/controller/updateServiceCategoryController.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\serviceCategories;
+use shared\utils\Validation;
+
+class UpdateServiceCategoryController
+{
+    private serviceCategories $categories;
+
+    public function __construct()
+    {
+        $this->categories = new serviceCategories();
+    }
+
+    public function update(int $id, array $input): bool
+    {
+        $name = Validation::sanitizeString($input['name'] ?? '');
+        $status = Validation::sanitizeString($input['status'] ?? 'active');
+
+        try {
+            Validation::requireField($name, 'Category name is required.');
+            Validation::requireField($status, 'Status is required.');
+        } catch (\InvalidArgumentException $exception) {
+            $_SESSION['category_message'] = $exception->getMessage();
+            return false;
+        }
+
+        $updated = $this->categories->update($id, $name, $status);
+        $_SESSION['category_message'] = $updated ? 'Category updated successfully.' : 'Unable to update category.';
+        return $updated;
+    }
+
+    public function find(int $id): ?array
+    {
+        return $this->categories->find($id);
+    }
+}

--- a/csit314-csr-platform/src/PM/controller/viewServiceCategoryController.php
+++ b/csit314-csr-platform/src/PM/controller/viewServiceCategoryController.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\serviceCategories;
+
+class ViewServiceCategoryController
+{
+    private serviceCategories $categories;
+
+    public function __construct()
+    {
+        $this->categories = new serviceCategories();
+    }
+
+    public function list(): array
+    {
+        return $this->categories->listAll();
+    }
+}

--- a/csit314-csr-platform/src/admin/boundary/CreateAccountUI.php
+++ b/csit314-csr-platform/src/admin/boundary/CreateAccountUI.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/createAccountController.php';
+require_once __DIR__ . '/../controller/viewProfilesController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$profilesController = new ViewProfilesController();
+$profiles = $profilesController->list();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $controller = new CreateAccountController();
+    if ($controller->create($_POST)) {
+        header('Location: /public/index.php?route=admin/view-accounts');
+        exit();
+    }
+}
+?>
+<section class="card">
+    <h1>Create User</h1>
+    <?php if (!empty($_SESSION['registration_message'])): ?>
+        <div class="alert alert-error"><?= htmlspecialchars($_SESSION['registration_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['registration_message']); ?>
+    <?php endif; ?>
+    <form method="POST" action="/public/index.php?route=admin/create-account" class="form">
+        <label>Name
+            <input type="text" name="name" value="<?= htmlspecialchars((string) ($_POST['name'] ?? ''), ENT_QUOTES) ?>" required>
+        </label>
+        <label>Email
+            <input type="email" name="email" value="<?= htmlspecialchars((string) ($_POST['email'] ?? ''), ENT_QUOTES) ?>" required>
+        </label>
+        <label>Password
+            <input type="password" name="password" required>
+        </label>
+        <label>Role
+            <select name="role" required>
+                <?php foreach ($profiles as $profile): ?>
+                    <option value="<?= htmlspecialchars($profile['role'] ?? '', ENT_QUOTES) ?>" <?= (($_POST['role'] ?? '') === ($profile['role'] ?? '')) ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($profile['role'] ?? '', ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/public/index.php?route=admin/view-accounts" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/admin/boundary/CreateProfileUI.php
+++ b/csit314-csr-platform/src/admin/boundary/CreateProfileUI.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/createProfileController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $controller = new CreateProfileController();
+    if ($controller->create($_POST)) {
+        header('Location: /public/index.php?route=admin/view-profiles');
+        exit();
+    }
+}
+?>
+<section class="card">
+    <h1>Create Profile</h1>
+    <?php if (!empty($_SESSION['profile_message'])): ?>
+        <div class="alert alert-error"><?= htmlspecialchars($_SESSION['profile_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['profile_message']); ?>
+    <?php endif; ?>
+    <form method="POST" action="/public/index.php?route=admin/create-profile" class="form">
+        <label>Role
+            <input type="text" name="role" value="<?= htmlspecialchars((string) ($_POST['role'] ?? ''), ENT_QUOTES) ?>" required>
+        </label>
+        <label>Description
+            <textarea name="description" required><?= htmlspecialchars((string) ($_POST['description'] ?? ''), ENT_QUOTES) ?></textarea>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/public/index.php?route=admin/view-profiles" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/admin/boundary/UpdateAccountUI.php
+++ b/csit314-csr-platform/src/admin/boundary/UpdateAccountUI.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/updateAccountController.php';
+require_once __DIR__ . '/../controller/viewProfilesController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+$controller = new UpdateAccountController();
+$user = $id ? $controller->find($id) : [];
+$profilesController = new ViewProfilesController();
+$profiles = $profilesController->list();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $id) {
+    if ($controller->update($id, $_POST)) {
+        header('Location: /public/index.php?route=admin/view-accounts');
+        exit();
+    }
+}
+?>
+<section class="card">
+    <h1>Edit User</h1>
+    <?php if (!empty($_SESSION['registration_message'])): ?>
+        <div class="alert alert-info"><?= htmlspecialchars($_SESSION['registration_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['registration_message']); ?>
+    <?php endif; ?>
+    <form method="POST" action="/public/index.php?route=admin/update-account&id=<?= (int) $id ?>" class="form">
+        <label>Name
+            <input type="text" value="<?= htmlspecialchars($user['name'] ?? '', ENT_QUOTES) ?>" disabled>
+        </label>
+        <label>Email
+            <input type="email" name="email" value="<?= htmlspecialchars((string) ($user['email'] ?? ''), ENT_QUOTES) ?>" required>
+        </label>
+        <label>Role
+            <select name="role" required>
+                <?php foreach ($profiles as $profile): ?>
+                    <option value="<?= htmlspecialchars($profile['role'] ?? '', ENT_QUOTES) ?>" <?= (($user['role'] ?? '') === ($profile['role'] ?? '')) ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($profile['role'] ?? '', ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label>Status
+            <select name="status">
+                <option value="active" <?= (($user['status'] ?? '') === 'active') ? 'selected' : '' ?>>Active</option>
+                <option value="suspended" <?= (($user['status'] ?? '') === 'suspended') ? 'selected' : '' ?>>Suspended</option>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/public/index.php?route=admin/view-accounts" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/admin/boundary/ViewAccountsUI.php
+++ b/csit314-csr-platform/src/admin/boundary/ViewAccountsUI.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/viewAccountsController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$controller = new ViewAccountsController();
+$search = $_GET['q'] ?? null;
+$role = $_GET['role'] ?? null;
+$users = $controller->list($search ? (string) $search : null, $role ? (string) $role : null);
+?>
+<section class="card">
+    <div class="card-header">
+        <h1>User Accounts</h1>
+        <a class="btn-primary" href="/public/index.php?route=admin/create-account">New User</a>
+    </div>
+    <?php if (!empty($_SESSION['registration_message'])): ?>
+        <div class="alert alert-info"><?= htmlspecialchars($_SESSION['registration_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['registration_message']); ?>
+    <?php endif; ?>
+    <form class="form-inline" method="GET" action="/public/index.php">
+        <input type="hidden" name="route" value="admin/view-accounts">
+        <input type="text" name="q" placeholder="Search email or name" value="<?= htmlspecialchars((string) ($search ?? ''), ENT_QUOTES) ?>">
+        <select name="role">
+            <option value="All">All Roles</option>
+            <option value="user_admin" <?= ($role ?? '') === 'user_admin' ? 'selected' : '' ?>>User Admin</option>
+            <option value="csr_rep" <?= ($role ?? '') === 'csr_rep' ? 'selected' : '' ?>>CSR Rep</option>
+            <option value="pin" <?= ($role ?? '') === 'pin' ? 'selected' : '' ?>>Person In Need</option>
+            <option value="platform_manager" <?= ($role ?? '') === 'platform_manager' ? 'selected' : '' ?>>Platform Manager</option>
+        </select>
+        <button type="submit" class="btn-secondary">Search</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th class="status-col">Status</th>
+                <th>Role</th>
+                <th class="actions">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($users as $user): ?>
+                <tr>
+                    <td><?= htmlspecialchars($user['name'] ?? '', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($user['email'] ?? '', ENT_QUOTES) ?></td>
+                    <td class="status-col"><span class="tag tag-<?= htmlspecialchars($user['status'] ?? '', ENT_QUOTES) ?>"><?= htmlspecialchars($user['status'] ?? '', ENT_QUOTES) ?></span></td>
+                    <td><?= htmlspecialchars($user['role'] ?? '', ENT_QUOTES) ?></td>
+                    <td class="actions">
+                        <a href="/public/index.php?route=admin/update-account&id=<?= (int) ($user['id'] ?? 0) ?>">Edit</a>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/admin/boundary/ViewProfilesUI.php
+++ b/csit314-csr-platform/src/admin/boundary/ViewProfilesUI.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/viewProfilesController.php';
+require_once __DIR__ . '/../controller/suspendProfileController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$controller = new ViewProfilesController();
+$profiles = $controller->list();
+
+if (isset($_POST['suspend_id'])) {
+    $suspendController = new SuspendProfileController();
+    $suspendController->suspend((int) $_POST['suspend_id']);
+    header('Location: /public/index.php?route=admin/view-profiles');
+    exit();
+}
+?>
+<section class="card">
+    <div class="card-header">
+        <h1>User Profiles</h1>
+        <a class="btn-primary" href="/public/index.php?route=admin/create-profile">New Profile</a>
+    </div>
+    <?php if (!empty($_SESSION['profile_message'])): ?>
+        <div class="alert alert-info"><?= htmlspecialchars($_SESSION['profile_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['profile_message']); ?>
+    <?php endif; ?>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Profile</th>
+                <th>Description</th>
+                <th class="status-col">Status</th>
+                <th class="actions">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (empty($profiles)): ?>
+                <tr>
+                    <td colspan="4" style="text-align: center;">No profiles found.</td>
+                </tr>
+            <?php endif; ?>
+            <?php foreach ($profiles as $profile): ?>
+                <tr>
+                    <td><strong><?= htmlspecialchars($profile['role'] ?? '', ENT_QUOTES) ?></strong></td>
+                    <td><?= htmlspecialchars($profile['description'] ?? '', ENT_QUOTES) ?></td>
+                    <td class="status-col"><span class="tag tag-<?= htmlspecialchars($profile['status'] ?? '', ENT_QUOTES) ?>"><?= htmlspecialchars($profile['status'] ?? '', ENT_QUOTES) ?></span></td>
+                    <td class="actions">
+                        <form method="POST" action="/public/index.php?route=admin/view-profiles" style="display:inline;">
+                            <input type="hidden" name="suspend_id" value="<?= (int) ($profile['id'] ?? 0) ?>">
+                            <button type="submit" class="btn-link">Suspend</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/admin/controller/createAccountController.php
+++ b/csit314-csr-platform/src/admin/controller/createAccountController.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\UserAccount;
+use shared\utils\Validation;
+
+class CreateAccountController
+{
+    private UserAccount $accounts;
+
+    public function __construct()
+    {
+        $this->accounts = new UserAccount();
+    }
+
+    public function create(array $input): bool
+    {
+        $name = Validation::sanitizeString($input['name'] ?? '');
+        $email = Validation::sanitizeString($input['email'] ?? '');
+        $password = $input['password'] ?? '';
+        $role = Validation::sanitizeString($input['role'] ?? '');
+
+        try {
+            Validation::requireField($name, 'Name is required.');
+            Validation::requireField($email, 'Email is required.');
+            Validation::email($email);
+            Validation::requireField($password, 'Password is required.');
+            Validation::requireField($role, 'Role is required.');
+        } catch (\InvalidArgumentException $exception) {
+            $_SESSION['registration_message'] = $exception->getMessage();
+            return false;
+        }
+
+        if (!$this->accounts->validateUA($role, $email, $password)) {
+            $_SESSION['registration_message'] = 'Email is already used or password is invalid.';
+            return false;
+        }
+
+        $this->accounts->registerUA($role, $name, $email, $password);
+        $_SESSION['registration_message'] = 'Account created successfully.';
+        return true;
+    }
+}

--- a/csit314-csr-platform/src/admin/controller/createProfileController.php
+++ b/csit314-csr-platform/src/admin/controller/createProfileController.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\UserProfiles;
+use shared\utils\Validation;
+
+class CreateProfileController
+{
+    private UserProfiles $profiles;
+
+    public function __construct()
+    {
+        $this->profiles = new UserProfiles();
+    }
+
+    public function create(array $input): bool
+    {
+        $role = Validation::sanitizeString($input['role'] ?? '');
+        $description = Validation::sanitizeString($input['description'] ?? '');
+
+        try {
+            Validation::requireField($role, 'Role is required.');
+            Validation::requireField($description, 'Description is required.');
+        } catch (\InvalidArgumentException $exception) {
+            $_SESSION['profile_message'] = $exception->getMessage();
+            return false;
+        }
+
+        $this->profiles->createProfile($role, $description);
+        $_SESSION['profile_message'] = 'Profile created successfully.';
+        return true;
+    }
+}

--- a/csit314-csr-platform/src/admin/controller/suspendProfileController.php
+++ b/csit314-csr-platform/src/admin/controller/suspendProfileController.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\UserProfiles;
+
+class SuspendProfileController
+{
+    private UserProfiles $profiles;
+
+    public function __construct()
+    {
+        $this->profiles = new UserProfiles();
+    }
+
+    public function suspend(int $id): bool
+    {
+        $success = $this->profiles->suspendProfile($id);
+        $_SESSION['profile_message'] = $success ? 'Profile suspended successfully.' : 'Unable to suspend profile.';
+        return $success;
+    }
+}

--- a/csit314-csr-platform/src/admin/controller/updateAccountController.php
+++ b/csit314-csr-platform/src/admin/controller/updateAccountController.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\UserAccount;
+use shared\utils\Validation;
+
+class UpdateAccountController
+{
+    private UserAccount $accounts;
+
+    public function __construct()
+    {
+        $this->accounts = new UserAccount();
+    }
+
+    public function update(int $id, array $input): bool
+    {
+        $email = Validation::sanitizeString($input['email'] ?? '');
+        $role = Validation::sanitizeString($input['role'] ?? '');
+        $status = Validation::sanitizeString($input['status'] ?? 'active');
+
+        try {
+            Validation::requireField($email, 'Email is required.');
+            Validation::email($email);
+            Validation::requireField($role, 'Role is required.');
+            Validation::requireField($status, 'Status is required.');
+        } catch (\InvalidArgumentException $exception) {
+            $_SESSION['registration_message'] = $exception->getMessage();
+            return false;
+        }
+
+        $success = $this->accounts->updateAccountDetails($id, $role, $email, $status);
+        if ($success) {
+            $_SESSION['registration_message'] = 'Account updated successfully.';
+        } else {
+            $_SESSION['registration_message'] = 'Unable to update account. Please try again.';
+        }
+        return $success;
+    }
+
+    public function find(int $id): array
+    {
+        return $this->accounts->getUserAccountList($id);
+    }
+}

--- a/csit314-csr-platform/src/admin/controller/viewAccountsController.php
+++ b/csit314-csr-platform/src/admin/controller/viewAccountsController.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\UserAccount;
+
+class ViewAccountsController
+{
+    private UserAccount $accounts;
+
+    public function __construct()
+    {
+        $this->accounts = new UserAccount();
+    }
+
+    public function list(?string $search = null, ?string $role = null): array
+    {
+        if ($search) {
+            return $this->accounts->searchUserAccounts($search);
+        }
+
+        if ($role && $role !== 'All') {
+            return $this->accounts->filterUserAccountsByType($role);
+        }
+
+        return $this->accounts->getUserAccountsList();
+    }
+}

--- a/csit314-csr-platform/src/admin/controller/viewProfilesController.php
+++ b/csit314-csr-platform/src/admin/controller/viewProfilesController.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\UserProfiles;
+
+class ViewProfilesController
+{
+    private UserProfiles $profiles;
+
+    public function __construct()
+    {
+        $this->profiles = new UserProfiles();
+    }
+
+    public function list(): array
+    {
+        return $this->profiles->listProfiles();
+    }
+}

--- a/csit314-csr-platform/src/csr-representative/boundary/SearchRequestUI.php
+++ b/csit314-csr-platform/src/csr-representative/boundary/SearchRequestUI.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/searchRequestController.php';
+require_once __DIR__ . '/../controller/saveRequestController.php';
+require_once __DIR__ . '/../controller/viewShortlistedRequestController.php';
+require_once __DIR__ . '/../controller/viewCSRHistoryController.php';
+require_once __DIR__ . '/../../PM/controller/viewServiceCategoryController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$categoryController = new ViewServiceCategoryController();
+$categories = $categoryController->list();
+
+$searchController = new SearchRequestController();
+$requests = $searchController->search($_GET);
+
+if (isset($_POST['shortlist_request'])) {
+    $csrId = (int) ($_SESSION['user']['id'] ?? 0);
+    if ($csrId) {
+        $saveController = new SaveRequestController();
+        $saveController->addToShortlist($csrId, (int) $_POST['shortlist_request']);
+    }
+    header('Location: /public/index.php?route=csr/search-requests');
+    exit();
+}
+?>
+<section class="card">
+    <h1>Volunteer Opportunities</h1>
+    <?php if (!empty($_SESSION['csr_message'])): ?>
+        <div class="alert alert-info"><?= htmlspecialchars($_SESSION['csr_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['csr_message']); ?>
+    <?php endif; ?>
+    <form class="form-inline" method="GET" action="/public/index.php">
+        <input type="hidden" name="route" value="csr/search-requests">
+        <input type="text" name="q" placeholder="Keyword" value="<?= htmlspecialchars((string) ($_GET['q'] ?? ''), ENT_QUOTES) ?>">
+        <select name="category">
+            <option value="">All categories</option>
+            <?php foreach ($categories as $category): ?>
+                <option value="<?= (int) $category['id'] ?>" <?= ((string) ($_GET['category'] ?? '') === (string) $category['id']) ? 'selected' : '' ?>>
+                    <?= htmlspecialchars($category['name'] ?? '', ENT_QUOTES) ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <button type="submit" class="btn-secondary">Filter</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Location</th>
+                <th>Date</th>
+                <th>Views</th>
+                <th>Shortlisted</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($requests as $requestItem): ?>
+                <tr>
+                    <td><?= htmlspecialchars($requestItem['title'] ?? '', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($requestItem['location'] ?? '', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($requestItem['requested_date'] ?? '', ENT_QUOTES) ?></td>
+                    <td><?= (int) ($requestItem['views_count'] ?? 0) ?></td>
+                    <td><?= (int) ($requestItem['shortlist_count'] ?? 0) ?></td>
+                    <td>
+                        <form method="POST" action="/public/index.php?route=csr/search-requests">
+                            <input type="hidden" name="shortlist_request" value="<?= (int) ($requestItem['id'] ?? 0) ?>">
+                            <button type="submit" class="btn-link">Shortlist</button>
+                            <a href="/public/index.php?route=csr/view-request&id=<?= (int) ($requestItem['id'] ?? 0) ?>" class="btn-link">View</a>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/csr-representative/boundary/ViewCSRHistoryUI.php
+++ b/csit314-csr-platform/src/csr-representative/boundary/ViewCSRHistoryUI.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/viewCSRHistoryController.php';
+require_once __DIR__ . '/../controller/searchCSRHistoryController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$csrId = (int) ($_SESSION['user']['id'] ?? 0);
+$controller = new ViewCSRHistoryController();
+$searchController = new SearchCSRHistoryController();
+$history = $csrId ? $searchController->search($csrId, $_GET) : [];
+?>
+<section class="card">
+    <h1>Service History</h1>
+    <form class="form-inline" method="GET" action="/public/index.php">
+        <input type="hidden" name="route" value="csr/history">
+        <input type="search" name="q" placeholder="Search history" value="<?= htmlspecialchars((string) ($_GET['q'] ?? ''), ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Filter</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Request</th>
+                <th>Status</th>
+                <th>Matched at</th>
+                <th>Completed</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($history as $item): ?>
+                <tr>
+                    <td>#<?= (int) ($item['id'] ?? 0) ?> - <?= htmlspecialchars($item['title'] ?? '', ENT_QUOTES) ?></td>
+                    <td><span class="tag tag-<?= htmlspecialchars(strtolower((string) ($item['match_status'] ?? 'open')), ENT_QUOTES) ?>"><?= htmlspecialchars($item['match_status'] ?? 'pending', ENT_QUOTES) ?></span></td>
+                    <td><?= htmlspecialchars($item['matched_at'] ?? '-', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($item['completed_at'] ?? '-', ENT_QUOTES) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/csr-representative/boundary/ViewRequestDetailUI.php
+++ b/csit314-csr-platform/src/csr-representative/boundary/ViewRequestDetailUI.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/saveRequestController.php';
+require_once __DIR__ . '/../../pin/controller/viewRequestController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$requestId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+$controller = new ViewRequestController();
+$request = $requestId ? $controller->find($requestId) : null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $requestId) {
+    $csrId = (int) ($_SESSION['user']['id'] ?? 0);
+    if ($csrId) {
+        $saveController = new SaveRequestController();
+        $saveController->addToShortlist($csrId, $requestId);
+    }
+    header('Location: /public/index.php?route=csr/view-request&id=' . $requestId);
+    exit();
+}
+?>
+<section class="card">
+    <?php if ($request): ?>
+        <h1><?= htmlspecialchars($request['title'] ?? '', ENT_QUOTES) ?></h1>
+        <p><?= nl2br(htmlspecialchars($request['description'] ?? '', ENT_QUOTES)) ?></p>
+        <p><strong>Location:</strong> <?= htmlspecialchars($request['location'] ?? '', ENT_QUOTES) ?></p>
+        <p><strong>Date:</strong> <?= htmlspecialchars($request['requested_date'] ?? '', ENT_QUOTES) ?></p>
+        <p><strong>Views:</strong> <?= (int) ($request['views_count'] ?? 0) ?> | <strong>Shortlists:</strong> <?= (int) ($request['shortlist_count'] ?? 0) ?></p>
+        <form method="POST" action="/public/index.php?route=csr/view-request&id=<?= (int) $requestId ?>">
+            <button type="submit" class="btn-primary">Add to shortlist</button>
+        </form>
+        <a href="/public/index.php?route=csr/search-requests" class="btn-secondary">Back</a>
+    <?php else: ?>
+        <p>Request not found.</p>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/csr-representative/boundary/ViewShortlistedRequestUI.php
+++ b/csit314-csr-platform/src/csr-representative/boundary/ViewShortlistedRequestUI.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/viewShortlistedRequestController.php';
+require_once __DIR__ . '/../controller/searchShortlistController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$csrId = (int) ($_SESSION['user']['id'] ?? 0);
+$controller = new ViewShortlistedRequestController();
+$searchController = new SearchShortlistController();
+$shortlist = $csrId ? $searchController->search($csrId, $_GET) : [];
+?>
+<section class="card">
+    <h1>My Shortlist</h1>
+    <form class="form-inline" method="GET" action="/public/index.php">
+        <input type="hidden" name="route" value="csr/shortlist">
+        <input type="search" name="q" placeholder="Search shortlist" value="<?= htmlspecialchars((string) ($_GET['q'] ?? ''), ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Search</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Request</th>
+                <th>Category</th>
+                <th>Status</th>
+                <th>Saved at</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($shortlist as $item): ?>
+                <tr>
+                    <td><a href="/public/index.php?route=csr/view-request&id=<?= (int) ($item['request_id'] ?? 0) ?>"><?= htmlspecialchars($item['title'] ?? ('Request #' . ($item['request_id'] ?? '')), ENT_QUOTES) ?></a></td>
+                    <td><?= htmlspecialchars($item['category_name'] ?? '', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($item['status'] ?? '', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($item['created_at'] ?? '', ENT_QUOTES) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/csr-representative/controller/saveRequestController.php
+++ b/csit314-csr-platform/src/csr-representative/controller/saveRequestController.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Shortlist;
+use shared\entity\Request;
+
+class SaveRequestController
+{
+    private Shortlist $shortlist;
+    private Request $requests;
+
+    public function __construct()
+    {
+        $this->shortlist = new Shortlist();
+        $this->requests = new Request();
+    }
+
+    public function addToShortlist(int $csrId, int $requestId): bool
+    {
+        $saved = $this->shortlist->add($csrId, $requestId);
+        if ($saved) {
+            $this->requests->updateShortlistCount($requestId, 1);
+            $_SESSION['csr_message'] = 'Request added to shortlist.';
+        } else {
+            $_SESSION['csr_message'] = 'Request is already in shortlist.';
+        }
+        return $saved;
+    }
+}

--- a/csit314-csr-platform/src/csr-representative/controller/searchCSRHistoryController.php
+++ b/csit314-csr-platform/src/csr-representative/controller/searchCSRHistoryController.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Request;
+use shared\utils\Validation;
+
+class SearchCSRHistoryController
+{
+    private Request $requests;
+
+    public function __construct()
+    {
+        $this->requests = new Request();
+    }
+
+    public function search(int $csrId, array $query): array
+    {
+        $term = Validation::sanitizeString($query['q'] ?? '');
+        $history = $this->requests->historyForCsr($csrId);
+        if ($term === '') {
+            return $history;
+        }
+
+        return array_values(array_filter($history, static function (array $row) use ($term): bool {
+            $needle = strtolower($term);
+            return str_contains(strtolower($row['title'] ?? ''), $needle)
+                || str_contains(strtolower($row['location'] ?? ''), $needle)
+                || str_contains(strtolower($row['status'] ?? ''), $needle);
+        }));
+    }
+}

--- a/csit314-csr-platform/src/csr-representative/controller/searchRequestController.php
+++ b/csit314-csr-platform/src/csr-representative/controller/searchRequestController.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Request;
+use shared\utils\Validation;
+
+class SearchRequestController
+{
+    private Request $requests;
+
+    public function __construct()
+    {
+        $this->requests = new Request();
+    }
+
+    public function search(array $query): array
+    {
+        $term = Validation::sanitizeString($query['q'] ?? '');
+        $categoryId = $query['category'] ?? null;
+        $categoryId = $categoryId ? (int) $categoryId : null;
+        return $this->requests->searchOpenRequests($term ?: null, $categoryId);
+    }
+}

--- a/csit314-csr-platform/src/csr-representative/controller/searchShortlistController.php
+++ b/csit314-csr-platform/src/csr-representative/controller/searchShortlistController.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Shortlist;
+use shared\utils\Validation;
+
+class SearchShortlistController
+{
+    private Shortlist $shortlist;
+
+    public function __construct()
+    {
+        $this->shortlist = new Shortlist();
+    }
+
+    public function search(int $csrId, array $query): array
+    {
+        $term = Validation::sanitizeString($query['q'] ?? '');
+        if ($term === '') {
+            return $this->shortlist->listForCsr($csrId);
+        }
+        return $this->shortlist->searchForCsr($csrId, $term);
+    }
+}

--- a/csit314-csr-platform/src/csr-representative/controller/viewCSRHistoryController.php
+++ b/csit314-csr-platform/src/csr-representative/controller/viewCSRHistoryController.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Request;
+
+class ViewCSRHistoryController
+{
+    private Request $requests;
+
+    public function __construct()
+    {
+        $this->requests = new Request();
+    }
+
+    public function list(int $csrId): array
+    {
+        return $this->requests->historyForCsr($csrId);
+    }
+}

--- a/csit314-csr-platform/src/csr-representative/controller/viewShortlistedRequestController.php
+++ b/csit314-csr-platform/src/csr-representative/controller/viewShortlistedRequestController.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Shortlist;
+
+class ViewShortlistedRequestController
+{
+    private Shortlist $shortlist;
+
+    public function __construct()
+    {
+        $this->shortlist = new Shortlist();
+    }
+
+    public function list(int $csrId): array
+    {
+        return $this->shortlist->listForCsr($csrId);
+    }
+}

--- a/csit314-csr-platform/src/login/boundary/loginUI.php
+++ b/csit314-csr-platform/src/login/boundary/loginUI.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/LoginController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$availableRoles = [
+    'user_admin' => 'User Administrator',
+    'csr_rep' => 'CSR Representative',
+    'pin' => 'Person In Need',
+    'platform_manager' => 'Platform Manager',
+];
+
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(16));
+}
+
+$controller = new LoginController();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $token = $_POST['_token'] ?? '';
+    if (!hash_equals($_SESSION['csrf_token'], $token)) {
+        $_SESSION['login_error'] = 'Invalid request token. Please try again.';
+    } else {
+        $email = trim((string) ($_POST['email'] ?? ''));
+        $password = (string) ($_POST['password'] ?? '');
+        $role = (string) ($_POST['role'] ?? '');
+        if ($controller->authenticate($email, $password, $role)) {
+            header('Location: /public/index.php?route=dashboard');
+            exit();
+        }
+    }
+}
+
+$selectedRole = $_POST['role'] ?? '';
+$emailValue = $_POST['email'] ?? '';
+?>
+<section class="card">
+    <h1>Sign in</h1>
+    <p class="tagline">Welcome to the CSR Match Platform. Choose your account type to continue.</p>
+    <?php if (!empty($_SESSION['login_error'])): ?>
+        <div class="alert alert-error"><?= htmlspecialchars($_SESSION['login_error'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['login_error']); ?>
+    <?php endif; ?>
+    <form method="POST" action="/public/index.php?route=login" class="form">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES) ?>">
+        <label for="role">I am logging in as
+            <select id="role" name="role" required>
+                <option value="" disabled <?= $selectedRole === '' ? 'selected' : '' ?>>Select an account type</option>
+                <?php foreach ($availableRoles as $roleKey => $roleLabel): ?>
+                    <option value="<?= htmlspecialchars((string) $roleKey, ENT_QUOTES) ?>" <?= $selectedRole === $roleKey ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($roleLabel, ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label for="email">Email
+            <input id="email" type="email" name="email" value="<?= htmlspecialchars((string) $emailValue, ENT_QUOTES) ?>" required>
+        </label>
+        <label for="password">Password
+            <input id="password" type="password" name="password" required>
+        </label>
+        <button type="submit" class="btn-primary">Sign in</button>
+    </form>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/login/controller/LoginController.php
+++ b/csit314-csr-platform/src/login/controller/LoginController.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\UserAccount;
+use shared\database\DatabaseConnection;
+use shared\database\DataGenerator;
+
+class LoginController
+{
+    private UserAccount $userAccount;
+
+    public function __construct()
+    {
+        DatabaseConnection::get();
+        DataGenerator::migrateAndSeed();
+        $this->userAccount = new UserAccount();
+    }
+
+    public function authenticate(string $email, string $password, string $role): bool
+    {
+        if (!$this->userAccount->validateUser($email, $password, $role)) {
+            $_SESSION['login_error'] = 'Invalid credentials or inactive account.';
+            return false;
+        }
+        $user = $this->userAccount->getUserData($role, $email);
+        $_SESSION['user'] = $user;
+        $_SESSION['user_role'] = $role;
+        return true;
+    }
+}

--- a/csit314-csr-platform/src/pin/boundary/CreateRequestUI.php
+++ b/csit314-csr-platform/src/pin/boundary/CreateRequestUI.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/createRequestController.php';
+require_once __DIR__ . '/../controller/searchPostedRequestsController.php';
+require_once __DIR__ . '/../controller/viewRequestShortlistCountController.php';
+require_once __DIR__ . '/../../PM/controller/viewServiceCategoryController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$categoryController = new ViewServiceCategoryController();
+$categories = $categoryController->list();
+$pinId = (int) ($_SESSION['user']['id'] ?? 0);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pinId) {
+    $controller = new CreateRequestController();
+    $requestId = $controller->create($pinId, $_POST);
+    if ($requestId) {
+        header('Location: /public/index.php?route=pin/my-requests');
+        exit();
+    }
+}
+?>
+<section class="card">
+    <h1>Create Request</h1>
+    <?php if (!empty($_SESSION['pin_message'])): ?>
+        <div class="alert alert-error"><?= htmlspecialchars($_SESSION['pin_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['pin_message']); ?>
+    <?php endif; ?>
+    <form method="POST" action="/public/index.php?route=pin/create-request" class="form">
+        <label>Title
+            <input type="text" name="title" value="<?= htmlspecialchars((string) ($_POST['title'] ?? ''), ENT_QUOTES) ?>" required>
+        </label>
+        <label>Description
+            <textarea name="description" required><?= htmlspecialchars((string) ($_POST['description'] ?? ''), ENT_QUOTES) ?></textarea>
+        </label>
+        <label>Location
+            <input type="text" name="location" value="<?= htmlspecialchars((string) ($_POST['location'] ?? ''), ENT_QUOTES) ?>" required>
+        </label>
+        <label>Requested Date
+            <input type="date" name="requested_date" value="<?= htmlspecialchars((string) ($_POST['requested_date'] ?? date('Y-m-d')), ENT_QUOTES) ?>" required>
+        </label>
+        <label>Category
+            <select name="category_id" required>
+                <option value="">Select category</option>
+                <?php foreach ($categories as $category): ?>
+                    <option value="<?= (int) $category['id'] ?>" <?= ((string) ($_POST['category_id'] ?? '') === (string) $category['id']) ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($category['name'] ?? '', ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="/public/index.php?route=pin/my-requests" class="btn-secondary">Cancel</a>
+    </form>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/pin/boundary/SearchPostedRequestsUI.php
+++ b/csit314-csr-platform/src/pin/boundary/SearchPostedRequestsUI.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/searchPostedRequestsController.php';
+require_once __DIR__ . '/../controller/viewRequestShortlistCountController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$pinId = (int) ($_SESSION['user']['id'] ?? 0);
+$controller = new SearchPostedRequestsController();
+$requests = $pinId ? $controller->search($pinId, $_GET) : [];
+?>
+<section class="card">
+    <div class="card-header">
+        <h1>My Requests</h1>
+        <a class="btn-primary" href="/public/index.php?route=pin/create-request">New Request</a>
+    </div>
+    <?php if (!empty($_SESSION['pin_message'])): ?>
+        <div class="alert alert-info"><?= htmlspecialchars($_SESSION['pin_message'], ENT_QUOTES) ?></div>
+        <?php unset($_SESSION['pin_message']); ?>
+    <?php endif; ?>
+    <form class="form-inline" method="GET" action="/public/index.php">
+        <input type="hidden" name="route" value="pin/my-requests">
+        <input type="search" name="q" placeholder="Search requests" value="<?= htmlspecialchars((string) ($_GET['q'] ?? ''), ENT_QUOTES) ?>">
+        <button type="submit" class="btn-secondary">Search</button>
+    </form>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th class="status-col">Status</th>
+                <th>Views</th>
+                <th>Shortlisted</th>
+                <th class="actions">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($requests as $requestItem): ?>
+                <tr>
+                    <td><?= htmlspecialchars($requestItem['title'] ?? '', ENT_QUOTES) ?></td>
+                    <td class="status-col"><span class="tag tag-<?= htmlspecialchars($requestItem['status'] ?? '', ENT_QUOTES) ?>"><?= htmlspecialchars($requestItem['status'] ?? '', ENT_QUOTES) ?></span></td>
+                    <td><?= (int) ($requestItem['views_count'] ?? 0) ?></td>
+                    <td><?= (int) ($requestItem['shortlist_count'] ?? 0) ?></td>
+                    <td class="actions">
+                        <a href="/public/index.php?route=pin/view-request&id=<?= (int) ($requestItem['id'] ?? 0) ?>">View</a>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/pin/boundary/ViewPINHistoryUI.php
+++ b/csit314-csr-platform/src/pin/boundary/ViewPINHistoryUI.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/viewPINHistoryController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$pinId = (int) ($_SESSION['user']['id'] ?? 0);
+$controller = new ViewPINHistoryController();
+$history = $pinId ? $controller->list($pinId) : [];
+?>
+<section class="card">
+    <h1>Completed Matches</h1>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Request</th>
+                <th>Status</th>
+                <th>Matched at</th>
+                <th>Completed</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($history as $item): ?>
+                <tr>
+                    <td>#<?= (int) ($item['id'] ?? 0) ?> - <?= htmlspecialchars($item['title'] ?? '', ENT_QUOTES) ?></td>
+                    <td><span class="tag tag-<?= htmlspecialchars($item['match_status'] ?? '', ENT_QUOTES) ?>"><?= htmlspecialchars($item['match_status'] ?? '', ENT_QUOTES) ?></span></td>
+                    <td><?= htmlspecialchars($item['matched_at'] ?? '-', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($item['completed_at'] ?? '-', ENT_QUOTES) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/pin/boundary/ViewRequestUI.php
+++ b/csit314-csr-platform/src/pin/boundary/ViewRequestUI.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../shared/bootstrap.php';
+require_once __DIR__ . '/../controller/viewRequestController.php';
+require_once __DIR__ . '/../controller/viewRequestShortlistCountController.php';
+include __DIR__ . '/../../shared/boundary/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$requestId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+$controller = new ViewRequestController();
+$request = $requestId ? $controller->find($requestId) : null;
+$shortlistController = new ViewRequestShortlistCountController();
+$shortlistCount = $requestId ? $shortlistController->count($requestId) : 0;
+?>
+<section class="card">
+    <?php if ($request): ?>
+        <h1><?= htmlspecialchars($request['title'] ?? '', ENT_QUOTES) ?></h1>
+        <p><?= nl2br(htmlspecialchars($request['description'] ?? '', ENT_QUOTES)) ?></p>
+        <dl class="definition-list">
+            <dt>Status</dt><dd><?= htmlspecialchars($request['status'] ?? '', ENT_QUOTES) ?></dd>
+            <dt>Requested Date</dt><dd><?= htmlspecialchars($request['requested_date'] ?? '', ENT_QUOTES) ?></dd>
+            <dt>Location</dt><dd><?= htmlspecialchars($request['location'] ?? '', ENT_QUOTES) ?></dd>
+            <dt>Views</dt><dd><?= (int) ($request['views_count'] ?? 0) ?></dd>
+            <dt>Shortlisted</dt><dd><?= (int) $shortlistCount ?></dd>
+        </dl>
+        <a href="/public/index.php?route=pin/my-requests" class="btn-secondary">Back</a>
+    <?php else: ?>
+        <p>Request not found.</p>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/../../shared/boundary/footer.php'; ?>

--- a/csit314-csr-platform/src/pin/controller/createRequestController.php
+++ b/csit314-csr-platform/src/pin/controller/createRequestController.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Request;
+use shared\utils\Validation;
+
+class CreateRequestController
+{
+    private Request $requests;
+
+    public function __construct()
+    {
+        $this->requests = new Request();
+    }
+
+    public function create(int $pinId, array $input): ?int
+    {
+        $title = Validation::sanitizeString($input['title'] ?? '');
+        $description = Validation::sanitizeString($input['description'] ?? '');
+        $location = Validation::sanitizeString($input['location'] ?? '');
+        $categoryId = isset($input['category_id']) ? (int) $input['category_id'] : 0;
+        $requestedDate = Validation::sanitizeString($input['requested_date'] ?? date('Y-m-d'));
+
+        try {
+            Validation::requireField($title, 'Title is required.');
+            Validation::requireField($description, 'Description is required.');
+            Validation::requireField($location, 'Location is required.');
+            if ($categoryId <= 0) {
+                throw new \InvalidArgumentException('Please choose a category.');
+            }
+        } catch (\InvalidArgumentException $exception) {
+            $_SESSION['pin_message'] = $exception->getMessage();
+            return null;
+        }
+
+        $requestId = $this->requests->create([
+            'pin_id' => $pinId,
+            'category_id' => $categoryId,
+            'title' => $title,
+            'description' => $description,
+            'location' => $location,
+            'status' => 'open',
+            'requested_date' => $requestedDate,
+        ]);
+        $_SESSION['pin_message'] = 'Request created successfully.';
+        return $requestId;
+    }
+}

--- a/csit314-csr-platform/src/pin/controller/searchPostedRequestsController.php
+++ b/csit314-csr-platform/src/pin/controller/searchPostedRequestsController.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Request;
+use shared\utils\Validation;
+
+class SearchPostedRequestsController
+{
+    private Request $requests;
+
+    public function __construct()
+    {
+        $this->requests = new Request();
+    }
+
+    public function search(int $pinId, array $query): array
+    {
+        $list = $this->requests->listByPin($pinId);
+        $term = Validation::sanitizeString($query['q'] ?? '');
+        if ($term === '') {
+            return $list;
+        }
+
+        $needle = strtolower($term);
+        return array_values(array_filter($list, static function (array $row) use ($needle): bool {
+            return str_contains(strtolower($row['title'] ?? ''), $needle)
+                || str_contains(strtolower($row['location'] ?? ''), $needle)
+                || str_contains(strtolower($row['status'] ?? ''), $needle);
+        }));
+    }
+}

--- a/csit314-csr-platform/src/pin/controller/viewPINHistoryController.php
+++ b/csit314-csr-platform/src/pin/controller/viewPINHistoryController.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Request;
+
+class ViewPINHistoryController
+{
+    private Request $requests;
+
+    public function __construct()
+    {
+        $this->requests = new Request();
+    }
+
+    public function list(int $pinId): array
+    {
+        return $this->requests->historyForPin($pinId);
+    }
+}

--- a/csit314-csr-platform/src/pin/controller/viewRequestController.php
+++ b/csit314-csr-platform/src/pin/controller/viewRequestController.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Request;
+
+class ViewRequestController
+{
+    private Request $requests;
+
+    public function __construct()
+    {
+        $this->requests = new Request();
+    }
+
+    public function find(int $requestId): ?array
+    {
+        $this->requests->incrementViewCount($requestId);
+        return $this->requests->find($requestId);
+    }
+}

--- a/csit314-csr-platform/src/pin/controller/viewRequestShortlistCountController.php
+++ b/csit314-csr-platform/src/pin/controller/viewRequestShortlistCountController.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use shared\entity\Shortlist;
+
+class ViewRequestShortlistCountController
+{
+    private Shortlist $shortlist;
+
+    public function __construct()
+    {
+        $this->shortlist = new Shortlist();
+    }
+
+    public function count(int $requestId): int
+    {
+        return $this->shortlist->shortlistCount($requestId);
+    }
+}

--- a/csit314-csr-platform/src/shared/bootstrap.php
+++ b/csit314-csr-platform/src/shared/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+$baseDir = __DIR__;
+require_once $baseDir . '/database/DatabaseConnection.php';
+require_once $baseDir . '/database/DataGenerator.php';
+require_once $baseDir . '/utils/Validation.php';
+require_once $baseDir . '/utils/Logger.php';
+require_once $baseDir . '/entity/UserAccount.php';
+require_once $baseDir . '/entity/UserProfiles.php';
+require_once $baseDir . '/entity/Request.php';
+require_once $baseDir . '/entity/Shortlist.php';
+require_once $baseDir . '/entity/serviceCategories.php';
+
+use shared\database\DatabaseConnection;
+use shared\database\DataGenerator;
+
+DatabaseConnection::get();
+DataGenerator::migrateAndSeed();

--- a/csit314-csr-platform/src/shared/boundary/DashboardUI.php
+++ b/csit314-csr-platform/src/shared/boundary/DashboardUI.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+include __DIR__ . '/header.php';
+
+function logout(): void
+{
+    session_destroy();
+    header('Location: /public/index.php?route=login');
+    exit();
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'logout') {
+    logout();
+}
+
+$user = $_SESSION['user'] ?? null;
+$role = $user['role'] ?? '';
+?>
+<section class="card">
+    <h1>Welcome, <?= htmlspecialchars($user['name'] ?? 'Guest', ENT_QUOTES) ?></h1>
+    <p>Your role: <?= htmlspecialchars($role, ENT_QUOTES) ?></p>
+    <div class="grid">
+        <?php if ($role === 'user_admin'): ?>
+            <a class="shortcut" href="/public/index.php?route=admin/view-accounts">Manage Users</a>
+            <a class="shortcut" href="/public/index.php?route=admin/view-profiles">Manage Profiles</a>
+            <a class="shortcut" href="/public/index.php?route=pm/categories">Service Categories</a>
+        <?php elseif ($role === 'csr_rep'): ?>
+            <a class="shortcut" href="/public/index.php?route=csr/search-requests">Browse Requests</a>
+            <a class="shortcut" href="/public/index.php?route=csr/shortlist">My Shortlist</a>
+            <a class="shortcut" href="/public/index.php?route=csr/history">Service History</a>
+        <?php elseif ($role === 'pin'): ?>
+            <a class="shortcut" href="/public/index.php?route=pin/my-requests">My Requests</a>
+            <a class="shortcut" href="/public/index.php?route=pin/create-request">Create Request</a>
+            <a class="shortcut" href="/public/index.php?route=pin/history">Completed Matches</a>
+        <?php elseif ($role === 'platform_manager'): ?>
+            <a class="shortcut" href="/public/index.php?route=pm/categories">Service Categories</a>
+            <a class="shortcut" href="/public/index.php?route=pm/daily-report">Daily Reports</a>
+            <a class="shortcut" href="/public/index.php?route=pm/weekly-report">Weekly Reports</a>
+        <?php else: ?>
+            <p>Please contact an administrator for assistance.</p>
+        <?php endif; ?>
+    </div>
+</section>
+<?php include __DIR__ . '/footer.php'; ?>

--- a/csit314-csr-platform/src/shared/boundary/footer.php
+++ b/csit314-csr-platform/src/shared/boundary/footer.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1); ?>
+</main>
+<footer class="site-footer">
+    <div class="container">&copy; <?= date('Y') ?> CSR Match Platform</div>
+</footer>
+</body>
+</html>

--- a/csit314-csr-platform/src/shared/boundary/header.php
+++ b/csit314-csr-platform/src/shared/boundary/header.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+$user = $_SESSION['user'] ?? null;
+$userRole = $_SESSION['user_role'] ?? null;
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CSR Match Platform</title>
+    <link rel="stylesheet" href="/public/css/style.css">
+</head>
+<body>
+<header class="site-header">
+    <div class="container">
+        <div class="branding">CSR Match Platform</div>
+        <nav>
+            <ul>
+                <?php if ($user): ?>
+                    <li><strong><?= htmlspecialchars($user['name'] ?? 'User', ENT_QUOTES) ?></strong> (<?= htmlspecialchars($userRole ?? 'guest', ENT_QUOTES) ?>)</li>
+                    <li><a href="?action=logout" class="logout-link">Logout</a></li>
+                <?php else: ?>
+                    <li><a href="/public/index.php?route=login">Login</a></li>
+                <?php endif; ?>
+            </ul>
+        </nav>
+    </div>
+</header>
+<main class="container">
+<?php if (isset($_SESSION['flash_message'])): ?>
+    <div class="alert alert-info"><?= htmlspecialchars($_SESSION['flash_message'], ENT_QUOTES) ?></div>
+    <?php unset($_SESSION['flash_message']); ?>
+<?php endif; ?>

--- a/csit314-csr-platform/src/shared/database/DataGenerator.php
+++ b/csit314-csr-platform/src/shared/database/DataGenerator.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\database;
+
+use PDO;
+
+class DataGenerator
+{
+    public static function migrateAndSeed(): void
+    {
+        $pdo = DatabaseConnection::get();
+        self::createTables($pdo);
+        self::seed($pdo);
+    }
+
+    private static function createTables(PDO $pdo): void
+    {
+        $tableExists = (bool) $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='profiles'")->fetchColumn();
+        if ($tableExists) {
+            return;
+        }
+
+        $schema = file_get_contents(dirname(__DIR__, 3) . '/create_data_table.sql');
+        $pdo->exec($schema);
+    }
+
+    private static function seed(PDO $pdo): void
+    {
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM profiles')->fetchColumn();
+        if ($count > 0) {
+            return;
+        }
+
+        $profiles = [
+            ['role' => 'user_admin', 'description' => 'User Administrator'],
+            ['role' => 'csr_rep', 'description' => 'CSR Representative'],
+            ['role' => 'pin', 'description' => 'Person In Need'],
+            ['role' => 'platform_manager', 'description' => 'Platform Manager'],
+        ];
+        $stmt = $pdo->prepare('INSERT INTO profiles (role, description, status) VALUES (:role, :description, :status)');
+        foreach ($profiles as $profile) {
+            $stmt->execute([
+                ':role' => $profile['role'],
+                ':description' => $profile['description'],
+                ':status' => 'active',
+            ]);
+        }
+
+        $users = [
+            ['profile_id' => 1, 'name' => 'Admin User', 'email' => 'admin@example.com', 'password' => 'password123', 'status' => 'active'],
+            ['profile_id' => 2, 'name' => 'CSR Representative', 'email' => 'csr.rep@example.com', 'password' => 'password123', 'status' => 'active'],
+            ['profile_id' => 3, 'name' => 'Person In Need', 'email' => 'pin.user@example.com', 'password' => 'password123', 'status' => 'active'],
+            ['profile_id' => 4, 'name' => 'Platform Manager', 'email' => 'manager@example.com', 'password' => 'password123', 'status' => 'active'],
+        ];
+        $userStmt = $pdo->prepare('INSERT INTO users (profile_id, name, email, password, status) VALUES (:profile_id, :name, :email, :password, :status)');
+        foreach ($users as $user) {
+            $userStmt->execute([
+                ':profile_id' => $user['profile_id'],
+                ':name' => $user['name'],
+                ':email' => $user['email'],
+                ':password' => password_hash($user['password'], PASSWORD_BCRYPT),
+                ':status' => $user['status'],
+            ]);
+        }
+
+        $categories = ['Food Assistance', 'Medical Support', 'Education Aid'];
+        $catStmt = $pdo->prepare('INSERT INTO service_categories (name, status) VALUES (:name, :status)');
+        foreach ($categories as $name) {
+            $catStmt->execute([':name' => $name, ':status' => 'active']);
+        }
+
+        $reqStmt = $pdo->prepare('INSERT INTO pin_requests (pin_id, category_id, title, description, location, status, requested_date, views_count, shortlist_count) VALUES (:pin_id, :category_id, :title, :description, :location, :status, :requested_date, :views_count, :shortlist_count)');
+        $requests = [
+            ['pin_id' => 3, 'category_id' => 1, 'title' => 'Groceries for elderly couple', 'description' => 'Need weekly groceries delivered.', 'location' => 'Downtown', 'status' => 'open', 'requested_date' => '2024-01-05'],
+            ['pin_id' => 3, 'category_id' => 2, 'title' => 'Medical appointment transport', 'description' => 'Need ride to hospital appointment.', 'location' => 'Uptown', 'status' => 'open', 'requested_date' => '2024-01-07'],
+            ['pin_id' => 3, 'category_id' => 3, 'title' => 'Tutoring support', 'description' => 'Math tutoring needed twice a week.', 'location' => 'Midtown', 'status' => 'matched', 'requested_date' => '2023-12-15'],
+        ];
+        foreach ($requests as $request) {
+            $reqStmt->execute([
+                ':pin_id' => $request['pin_id'],
+                ':category_id' => $request['category_id'],
+                ':title' => $request['title'],
+                ':description' => $request['description'],
+                ':location' => $request['location'],
+                ':status' => $request['status'],
+                ':requested_date' => $request['requested_date'],
+                ':views_count' => rand(10, 80),
+                ':shortlist_count' => rand(1, 12),
+            ]);
+        }
+    }
+}

--- a/csit314-csr-platform/src/shared/database/DatabaseConnection.php
+++ b/csit314-csr-platform/src/shared/database/DatabaseConnection.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\database;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class DatabaseConnection
+{
+    private static ?PDO $connection = null;
+
+    public static function get(): PDO
+    {
+        if (self::$connection instanceof PDO) {
+            return self::$connection;
+        }
+
+        $config = require dirname(__DIR__, 3) . '/config/database.php';
+        $dsn = $config['dsn'] ?? null;
+        if (!$dsn) {
+            throw new RuntimeException('Database DSN is not configured.');
+        }
+
+        try {
+            $pdo = new PDO($dsn, $config['username'] ?? null, $config['password'] ?? null);
+            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Unable to connect to the database: ' . $exception->getMessage());
+        }
+
+        if (str_starts_with($dsn, 'sqlite:')) {
+            $pdo->exec('PRAGMA foreign_keys = ON');
+        }
+
+        self::$connection = $pdo;
+        return $pdo;
+    }
+}

--- a/csit314-csr-platform/src/shared/entity/Request.php
+++ b/csit314-csr-platform/src/shared/entity/Request.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\entity;
+
+use shared\database\DatabaseConnection;
+use PDO;
+
+class Request
+{
+    public function create(array $data): int
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('INSERT INTO pin_requests (pin_id, category_id, title, description, location, status, requested_date, views_count, shortlist_count)
+            VALUES (:pin_id, :category_id, :title, :description, :location, :status, :requested_date, 0, 0)');
+        $stmt->execute([
+            ':pin_id' => $data['pin_id'],
+            ':category_id' => $data['category_id'],
+            ':title' => $data['title'],
+            ':description' => $data['description'],
+            ':location' => $data['location'],
+            ':status' => $data['status'] ?? 'open',
+            ':requested_date' => $data['requested_date'],
+        ]);
+        return (int) $pdo->lastInsertId();
+    }
+
+    public function listByPin(int $pinId): array
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT pr.*, sc.name AS category_name FROM pin_requests pr JOIN service_categories sc ON pr.category_id = sc.id WHERE pr.pin_id = :pin ORDER BY pr.id DESC');
+        $stmt->execute([':pin' => $pinId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function find(int $requestId): ?array
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT pr.*, sc.name AS category_name, u.name AS pin_name FROM pin_requests pr
+            JOIN service_categories sc ON pr.category_id = sc.id
+            JOIN users u ON pr.pin_id = u.id WHERE pr.id = :id');
+        $stmt->execute([':id' => $requestId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public function incrementViewCount(int $requestId): void
+    {
+        $pdo = DatabaseConnection::get();
+        $pdo->prepare('UPDATE pin_requests SET views_count = views_count + 1 WHERE id = :id')->execute([':id' => $requestId]);
+    }
+
+    public function searchOpenRequests(?string $term = null, ?int $categoryId = null): array
+    {
+        $pdo = DatabaseConnection::get();
+        $conditions = ["pr.status = 'open'"];
+        $params = [];
+        if ($term) {
+            $conditions[] = '(LOWER(pr.title) LIKE LOWER(:term) OR LOWER(pr.description) LIKE LOWER(:term))';
+            $params[':term'] = '%' . $term . '%';
+        }
+        if ($categoryId) {
+            $conditions[] = 'pr.category_id = :category';
+            $params[':category'] = $categoryId;
+        }
+        $where = implode(' AND ', $conditions);
+        $sql = 'SELECT pr.*, sc.name AS category_name, u.name AS pin_name FROM pin_requests pr
+                JOIN service_categories sc ON pr.category_id = sc.id
+                JOIN users u ON pr.pin_id = u.id
+                WHERE ' . $where . ' ORDER BY pr.requested_date DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function updateShortlistCount(int $requestId, int $delta = 1): void
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('UPDATE pin_requests SET shortlist_count = shortlist_count + :delta WHERE id = :id');
+        $stmt->execute([':delta' => $delta, ':id' => $requestId]);
+    }
+
+    public function historyForPin(int $pinId): array
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT pr.*, m.status AS match_status, m.matched_at, m.completed_at FROM pin_requests pr
+            LEFT JOIN matches m ON m.request_id = pr.id
+            WHERE pr.pin_id = :pin AND pr.status != "open" ORDER BY pr.requested_date DESC');
+        $stmt->execute([':pin' => $pinId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function historyForCsr(int $csrId): array
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT pr.*, m.status AS match_status, m.matched_at, m.completed_at FROM matches m
+            JOIN pin_requests pr ON m.request_id = pr.id WHERE m.csr_id = :csr ORDER BY m.matched_at DESC');
+        $stmt->execute([':csr' => $csrId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/csit314-csr-platform/src/shared/entity/Shortlist.php
+++ b/csit314-csr-platform/src/shared/entity/Shortlist.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\entity;
+
+use shared\database\DatabaseConnection;
+use PDO;
+
+class Shortlist
+{
+    public function add(int $csrId, int $requestId): bool
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('INSERT OR IGNORE INTO shortlists (csr_id, request_id) VALUES (:csr, :request)');
+        return $stmt->execute([':csr' => $csrId, ':request' => $requestId]);
+    }
+
+    public function listForCsr(int $csrId): array
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT s.*, pr.title, pr.location, pr.status, sc.name AS category_name
+                FROM shortlists s
+                JOIN pin_requests pr ON s.request_id = pr.id
+                JOIN service_categories sc ON pr.category_id = sc.id
+                WHERE s.csr_id = :csr ORDER BY s.created_at DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([':csr' => $csrId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function searchForCsr(int $csrId, string $term): array
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT s.*, pr.title, pr.location, pr.status, sc.name AS category_name
+                FROM shortlists s
+                JOIN pin_requests pr ON s.request_id = pr.id
+                JOIN service_categories sc ON pr.category_id = sc.id
+                WHERE s.csr_id = :csr AND (LOWER(pr.title) LIKE LOWER(:term) OR LOWER(pr.location) LIKE LOWER(:term))
+                ORDER BY s.created_at DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([':csr' => $csrId, ':term' => '%' . $term . '%']);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function shortlistCount(int $requestId): int
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT COUNT(*) FROM shortlists WHERE request_id = :request');
+        $stmt->execute([':request' => $requestId]);
+        return (int) $stmt->fetchColumn();
+    }
+}

--- a/csit314-csr-platform/src/shared/entity/UserAccount.php
+++ b/csit314-csr-platform/src/shared/entity/UserAccount.php
@@ -1,0 +1,161 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\entity;
+
+use shared\database\DatabaseConnection;
+use PDO;
+
+class UserAccount
+{
+    private array $userData = [];
+
+    public function validateUser(string $email, string $password, string $userType): bool
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT u.password FROM users u JOIN profiles p ON u.profile_id = p.id
+                WHERE u.status = "active" AND p.role = :role AND LOWER(u.email) = LOWER(:email)
+                LIMIT 1';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([':role' => $userType, ':email' => $email]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            return false;
+        }
+        $dbPassword = (string) $row['password'];
+        if (password_verify($password, $dbPassword) || $password === $dbPassword) {
+            return true;
+        }
+        return false;
+    }
+
+    public function validatePassword(string $password): bool
+    {
+        $pattern = '/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/';
+        return (bool) preg_match($pattern, $password);
+    }
+
+    public function validateUA(string $userType, string $email, string $password): bool
+    {
+        $pdo = DatabaseConnection::get();
+        $existsSql = 'SELECT 1 FROM users u JOIN profiles p ON u.profile_id = p.id
+                      WHERE LOWER(u.email) = LOWER(:email) AND p.role = :role LIMIT 1';
+        $stmt = $pdo->prepare($existsSql);
+        $stmt->execute([':email' => $email, ':role' => $userType]);
+        $emailExists = (bool) $stmt->fetchColumn();
+        $passwordIsCorrect = $this->validatePassword($password);
+        return (!$emailExists && $passwordIsCorrect);
+    }
+
+    public function registerUA(string $userType, string $name, string $email, string $password): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        $pdo = DatabaseConnection::get();
+        $profileId = $this->getProfileIdByRole($userType);
+        $sql = 'INSERT INTO users (profile_id, name, email, password) VALUES (:profile_id, :name, :email, :password)';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([
+            ':profile_id' => $profileId,
+            ':name' => $name,
+            ':email' => $email,
+            ':password' => password_hash($password, PASSWORD_BCRYPT),
+        ]);
+        $_SESSION['userID'] = (int) $pdo->lastInsertId();
+    }
+
+    public function getUserData(string $userType, string $email): array
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT u.*, p.role FROM users u JOIN profiles p ON u.profile_id = p.id
+                WHERE p.role = :role AND LOWER(u.email) = LOWER(:email)
+                LIMIT 1';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([':role' => $userType, ':email' => $email]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->userData = $row ? $row : [];
+        return $this->userData;
+    }
+
+    public function getUserAccountsList(): array
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT u.*, p.role FROM users u JOIN profiles p ON u.profile_id = p.id ORDER BY u.id DESC';
+        return $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function filterUserAccountsByType(string $type): array
+    {
+        if ($type === 'All') {
+            return $this->getUserAccountsList();
+        }
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT u.*, p.role FROM users u JOIN profiles p ON u.profile_id = p.id
+                WHERE p.role = :role ORDER BY u.id DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([':role' => $type]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function searchUserAccounts(string $searchQuery): array
+    {
+        $pdo = DatabaseConnection::get();
+        $like = '%' . $searchQuery . '%';
+        $sql = 'SELECT u.*, p.role FROM users u JOIN profiles p ON u.profile_id = p.id
+                WHERE LOWER(u.name) LIKE LOWER(:q) OR LOWER(u.email) LIKE LOWER(:q)
+                ORDER BY u.id DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([':q' => $like]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getUserAccountList(int $userID): array
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT u.*, p.role FROM users u JOIN profiles p ON u.profile_id = p.id WHERE u.id = :id';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([':id' => $userID]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? $row : [];
+    }
+
+    public function updateAccountDetails(int $userID, string $type, string $email, string $status): bool
+    {
+        $pdo = DatabaseConnection::get();
+        $profileId = $this->getProfileIdByRole($type);
+        $sql = 'UPDATE users SET profile_id = :profile_id, email = :email, status = :status WHERE id = :id';
+        $stmt = $pdo->prepare($sql);
+        return $stmt->execute([
+            ':profile_id' => $profileId,
+            ':email' => $email,
+            ':status' => $status,
+            ':id' => $userID,
+        ]);
+    }
+
+    public function getSellerID(string $sellerEmail): int
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = "SELECT id FROM users WHERE LOWER(email) = LOWER(:email) LIMIT 1";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([':email' => $sellerEmail]);
+        $id = $stmt->fetchColumn();
+        return $id ? (int) $id : 0;
+    }
+
+    private function getProfileIdByRole(string $role): int
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT id FROM profiles WHERE role = :role LIMIT 1');
+        $stmt->execute([':role' => $role]);
+        $id = $stmt->fetchColumn();
+        if (!$id) {
+            $pdo->prepare('INSERT INTO profiles (role, description, status) VALUES (:role, :description, :status)')
+                ->execute([':role' => $role, ':description' => ucfirst(str_replace('_', ' ', $role)), ':status' => 'active']);
+            $id = $pdo->lastInsertId();
+        }
+        return (int) $id;
+    }
+}

--- a/csit314-csr-platform/src/shared/entity/UserProfiles.php
+++ b/csit314-csr-platform/src/shared/entity/UserProfiles.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\entity;
+
+use shared\database\DatabaseConnection;
+use PDO;
+
+class UserProfiles
+{
+    public function listProfiles(): array
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT * FROM profiles ORDER BY id DESC';
+        return $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function findProfile(int $id): ?array
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT * FROM profiles WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public function createProfile(string $role, string $description): int
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('INSERT INTO profiles (role, description, status) VALUES (:role, :description, :status)');
+        $stmt->execute([
+            ':role' => $role,
+            ':description' => $description,
+            ':status' => 'active',
+        ]);
+        return (int) $pdo->lastInsertId();
+    }
+
+    public function suspendProfile(int $id): bool
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('UPDATE profiles SET status = :status WHERE id = :id');
+        return $stmt->execute([':status' => 'suspended', ':id' => $id]);
+    }
+}

--- a/csit314-csr-platform/src/shared/entity/serviceCategories.php
+++ b/csit314-csr-platform/src/shared/entity/serviceCategories.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\entity;
+
+use shared\database\DatabaseConnection;
+use PDO;
+
+class serviceCategories
+{
+    public function listAll(): array
+    {
+        $pdo = DatabaseConnection::get();
+        $sql = 'SELECT * FROM service_categories ORDER BY name ASC';
+        return $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function find(int $id): ?array
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('SELECT * FROM service_categories WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public function update(int $id, string $name, string $status): bool
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('UPDATE service_categories SET name = :name, status = :status WHERE id = :id');
+        return $stmt->execute([':name' => $name, ':status' => $status, ':id' => $id]);
+    }
+
+    public function create(string $name, string $status = 'active'): int
+    {
+        $pdo = DatabaseConnection::get();
+        $stmt = $pdo->prepare('INSERT INTO service_categories (name, status) VALUES (:name, :status)');
+        $stmt->execute([':name' => $name, ':status' => $status]);
+        return (int) $pdo->lastInsertId();
+    }
+}

--- a/csit314-csr-platform/src/shared/utils/Logger.php
+++ b/csit314-csr-platform/src/shared/utils/Logger.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\utils;
+
+class Logger
+{
+    public static function info(string $message, array $context = []): void
+    {
+        self::writeLog('INFO', $message, $context);
+    }
+
+    public static function error(string $message, array $context = []): void
+    {
+        self::writeLog('ERROR', $message, $context);
+    }
+
+    private static function writeLog(string $level, string $message, array $context): void
+    {
+        $logDir = dirname(__DIR__, 3) . '/storage/logs';
+        if (!is_dir($logDir)) {
+            mkdir($logDir, 0775, true);
+        }
+        $entry = sprintf(
+            "[%s] %s %s %s\n",
+            date('Y-m-d H:i:s'),
+            $level,
+            $message,
+            $context ? json_encode($context, JSON_UNESCAPED_UNICODE) : ''
+        );
+        file_put_contents($logDir . '/app.log', $entry, FILE_APPEND);
+    }
+}

--- a/csit314-csr-platform/src/shared/utils/Validation.php
+++ b/csit314-csr-platform/src/shared/utils/Validation.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace shared\utils;
+
+class Validation
+{
+    public static function sanitizeString(?string $value): string
+    {
+        return trim((string) $value);
+    }
+
+    public static function requireField(string $value, string $message): void
+    {
+        if ($value === '') {
+            throw new \InvalidArgumentException($message);
+        }
+    }
+
+    public static function email(string $value): void
+    {
+        if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            throw new \InvalidArgumentException('Please provide a valid email address.');
+        }
+    }
+
+    public static function integerId($value): int
+    {
+        if (!is_numeric($value)) {
+            throw new \InvalidArgumentException('A valid identifier is required.');
+        }
+        return (int) $value;
+    }
+}

--- a/csit314-csr-platform/src/tests/README.md
+++ b/csit314-csr-platform/src/tests/README.md
@@ -1,0 +1,3 @@
+# Test Suite
+
+Add PHPUnit or integration tests for the BCE modules in this directory.


### PR DESCRIPTION
## Summary
- add a new csit314-csr-platform directory structured by module with boundary/controller/entity layers
- migrate the existing HTML views into boundary scripts that call role-specific controllers and shared entities
- wire up a lightweight router, bootstrap, and SQLite-backed data seeding to keep the application functional without any framework dependencies

## Testing
- php csit314-csr-platform/scripts/generate-test-data.php

------
https://chatgpt.com/codex/tasks/task_e_68f8ef00b35c833189c1647e28eab5b3